### PR TITLE
Add __getslice__ method to newbytes

### DIFF
--- a/future/builtins/backports/newbytes.py
+++ b/future/builtins/backports/newbytes.py
@@ -88,6 +88,9 @@ class newbytes(_builtin_bytes):
         else:
             return newbytes(value)
 
+    def __getslice__(self, *args):
+        return self.__getitem__(slice(*args))
+
     def __contains__(self, key):
         if isinstance(key, int):
             newbyteskey = newbytes([key])


### PR DESCRIPTION
Currently in Python 2.x:

```
>>> from future.builtins import bytes
>>> b = bytes(b'123')
>>> type(b[:])
<type 'str'>
```

Should be:

```
>>> from future.builtins import bytes
>>> b = bytes(b'123')
>>> type(b[:])
<class 'future.builtins.backports.newbytes.newbytes'>
```

For some reason slicing calls not __getitem__ with slice object as argument but __getslice__ although it is [deprecated since 2.0](http://docs.python.org/2/reference/datamodel.html#object.__getslice__).
