### PR TITLE
Fix "TypeError: type() argument 1 must be string, not unicode" in Python...

### DIFF
--- a/future/utils/__init__.py
+++ b/future/utils/__init__.py
@@ -123,7 +123,7 @@ def with_metaclass(meta, *bases):
             if this_bases is None:
                 return type.__new__(cls, name, (), d)
             return meta(name, bases, d)
-    return metaclass('temporary_class', None, {})
+    return metaclass(native_str('temporary_class'), None, {})
 
 
 # Definitions from pandas.compat follow:


### PR DESCRIPTION
Fix "TypeError: type() argument 1 must be string, not unicode" in Python 2
