### PR TITLE
Fix reraise

### DIFF
--- a/future/tests/test_utils.py
+++ b/future/tests/test_utils.py
@@ -4,8 +4,11 @@ Tests for the various utility functions and classes in ``future.utils``
 """
 
 from __future__ import absolute_import, unicode_literals, print_function
+import sys
 from future.builtins import *
-from future.utils import old_div, istext, isbytes, native, PY2, PY3, native_str
+from future.utils import (old_div, istext, isbytes, native, PY2, PY3,
+                         native_str, reraise)
+
 
 from numbers import Integral
 from future.tests.base import unittest
@@ -95,6 +98,40 @@ class TestUtils(unittest.TestCase):
         self.assertTrue(isbytes(self.b2))
         self.assertFalse(isbytes(self.s))
         self.assertFalse(isbytes(self.s2))
+
+    def test_reraise(self):
+        def valerror():
+            try:
+                raise ValueError("Apples!")
+            except Exception as e:
+                reraise(e)
+
+        self.assertRaises(ValueError, valerror)
+
+        def with_value():
+            reraise(IOError, "This is an error")
+
+        self.assertRaises(IOError, with_value)
+
+        try:
+            with_value()
+        except IOError as e:
+            self.assertEqual(str(e), "This is an error")
+
+        def with_traceback():
+            try:
+                raise ValueError("An error")
+            except Exception as e:
+                _, _, traceback = sys.exc_info()
+                reraise(IOError, str(e), traceback)
+
+        self.assertRaises(IOError, with_traceback)
+
+        try:
+            with_traceback()
+        except IOError as e:
+            self.assertEqual(str(e), "An error")
+
 
 
 if __name__ == '__main__':

--- a/future/utils/__init__.py
+++ b/future/utils/__init__.py
@@ -312,17 +312,26 @@ def getexception():
     return sys.exc_info()[1]
 
 
+if PY3:
+    def reraise(tp, value=None, tb=None):
+        """
+        Create a raise_ method that allows re-raising exceptions with the cls
+        value and traceback on Python2 & Python3.
+        """
+        if value is not None and isinstance(tp, Exception):
+            raise TypeError("instance exception may not have a separate value")
+        if value is not None:
+            exc = tp(value)
+        else:
+            exc = tp
+        if exc.__traceback__ is not tb:
+            raise exc.with_traceback(tb)
+
+else:
+    exec('''
 def reraise(tp, value=None, tb=None):
-    """
-    Create a raise_ method that allows re-raising exceptions with the cls
-    value and traceback on Python2 & Python3.
-    """
-    if PY3:
-        if value.__traceback__ is not tb:
-            raise value.with_traceback(tb)
-        raise value
-    else:
-        exec('def reraise(tp, value=None, tb=None):\n raise tp, value, tb')
+    raise tp, value, tb
+'''.strip())
 
 
 def implements_iterator(cls):


### PR DESCRIPTION
I'm not totally clear on what reraise was supposed to do, but this PR
attempts to change it to just match the current Python 2.X `raise_`
statement. I added some tests to validate the behavior of reraise as
well.

I would advocate for you renaming `reraise` --> `raise_` and then
potentially adding a raise_with_traceback function like in pandas to
preserve that Python3.X compatible behavior.
