### PR TITLE
future.builtins.newbytes: find and rfind should return a position

### DIFF
--- a/future/builtins/types/newbytes.py
+++ b/future/builtins/types/newbytes.py
@@ -163,11 +163,11 @@ class newbytes(with_metaclass(BaseNewBytes, _builtin_bytes)):
 
     @no(unicode)
     def find(self, sub, *args):
-        return newbytes(super(newbytes, self).find(sub, *args))
+        return super(newbytes, self).find(sub, *args)
 
     @no(unicode)
     def rfind(self, sub, *args):
-        return newbytes(super(newbytes, self).rfind(sub, *args))
+        return super(newbytes, self).rfind(sub, *args)
 
     @no(unicode, (1, 2))
     def replace(self, old, new, *args):

--- a/future/tests/test_bytes.py
+++ b/future/tests/test_bytes.py
@@ -168,6 +168,18 @@ class TestBytes(unittest.TestCase):
         self.assertEqual(b4, b'ZYXWABCD')
         self.assertTrue(isinstance(b4, bytes))
 
+    def test_find_not_found(self):
+        self.assertEqual(-1, bytes(b'ABCDE').find(b':'))
+
+    def test_find_found(self):
+        self.assertEqual(2, bytes(b'AB:CD:E').find(b':'))
+
+    def test_rfind_not_found(self):
+        self.assertEqual(-1, bytes(b'ABCDE').find(b':'))
+
+    def test_rfind_found(self):
+        self.assertEqual(4, bytes(b'AB:CD:E').find(b':'))
+
     def test_bytes_join_bytes(self):
         b = bytes(b' * ')
         strings = [b'AB', b'EFGH', b'IJKL']


### PR DESCRIPTION
Stumbled on this while using newbytes/newstr in my application. 
find returns a position, so when we override it we should not try to convert it somehow. 
Ran tests (test_bytes.py) on py3 and py2, seems fine. Other tests seem to be broken im master, so i couldn't really check them. 

Currently based on master, I can rebase if the dev/bugfix-branch is another one. 
