### PR TITLE
Contradictory terminology about native types

### DIFF
--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -247,9 +247,9 @@ Many small improvements and fixes have been made across the project. Some highli
 
 - Improved compatibility with py2exe (`issue #31 <https://github.com/PythonCharmers/python-future/issues/31>`_).
 
-- The ``future.utils.bytes_to_native_str`` function now returns a ``newbytes``
-  object on Py2. (`Issue #47
-  <https://github.com/PythonCharmers/python-future/issues/47>`_).
+- The ``future.utils.bytes_to_native_str`` function now returns a ``native_str``
+  object and ``future.utils.native_str_to_bytes`` returns a ``newbytes`` on Py2.
+  (`Issue #47 <https://github.com/PythonCharmers/python-future/issues/47>`_).
 
 - The backported ``http.client`` module and related modules use other new
   backported modules such as ``email``. As a result they are more compliant


### PR DESCRIPTION
Currently `future.utils.native_str` is the default native string type.

One would therefore conclude that `future.utils.bytes_to_native_str` was the correct way to turn `newbytes` into a `native_str`, at least on Python 2. This does not work, as it is in fact a no-op on Python 2.

Personally this could be solved with a hint in the docstring (and a pointer to use `native`), but it could also be seen as a naming or coding bug.

Thanks for the lovely work. :)
