### PR TITLE
moves.http.server and python2.7.3

### DIFF
--- a/future/moves/http/server.py
+++ b/future/moves/http/server.py
@@ -8,4 +8,9 @@ else:
     from BaseHTTPServer import *
     from CGIHTTPServer import *
     from SimpleHTTPServer import *
-    from CGIHTTPServer import _url_collapse_path     # needed for a test
+    try:
+        from CGIHTTPServer import _url_collapse_path     # needed for a test
+    except ImportError:
+        # python 2.7.3
+        from CGIHTTPServer import (
+            _url_collapse_path_split as _url_collapse_path)


### PR DESCRIPTION
_url_collapse_path was named _url_collapse_path_split for older version of python 2.7
