### PR TITLE
Fix reuseport exception

### DIFF
--- a/future/backports/test/support.py
+++ b/future/backports/test/support.py
@@ -595,7 +595,7 @@ def bind_port(sock, host=HOST):
                 if sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT) == 1:
                     raise TestFailed("tests should never set the SO_REUSEPORT "   \
                                      "socket option on TCP/IP sockets!")
-            except OSError:
+            except socket.error:
                 # Python's socket module was compiled using modern headers
                 # thus defining SO_REUSEPORT but this process is running
                 # under an older kernel that does not support SO_REUSEPORT.


### PR DESCRIPTION
In Python 3.3, exceptions on sockets raise `OSError`, but since this code is a backport for 2.x, it needs to use the previous exception type, namely, `socket.error`.
