### PR TITLE
Fix ensure_new_type with long input

### DIFF
--- a/future/utils/__init__.py
+++ b/future/utils/__init__.py
@@ -610,6 +610,8 @@ else:
                 return newstr(obj)
             elif native_type == int:
                 return newint(obj)
+            elif native_type == long:
+                return newint(obj)
             elif native_type == dict:
                 return newdict(obj)
             else:


### PR DESCRIPTION
`ensure_new_type` fails when given input with type `long`. Given that it converts `int` to `newint`, I assume that `long` should do the same thing. This fixes a test error on 32-bit installs (where a `long` is created more readily).
