### PR TITLE
Fix standard library hook test

### DIFF
--- a/past/tests/test_translation.py
+++ b/past/tests/test_translation.py
@@ -118,6 +118,8 @@ class TestTranslate(unittest.TestCase):
         """
         module = self.write_and_import(code, 'future_standard_library')
         self.assertTrue('configparser' in dir(module))
+        from future import standard_library
+        standard_library.remove_hooks()
 
     def test_old_builtin_functions(self):
         code = """


### PR DESCRIPTION
In `past/tests/test_translation.py`, the test framework calls `remove_hook()` from `past`, but the `test_import_future_standard_library` test installs hooks from `future`, so they bleed through depending on what tests you run (since some remove the hooks).
