### PR TITLE
Fix object.__format__ test on Python 3.4.

### DIFF
--- a/future/tests/test_builtins.py
+++ b/future/tests/test_builtins.py
@@ -1726,9 +1726,18 @@ class BuiltinTest(unittest.TestCase):
         # Issue #7994: object.__format__ with a non-empty format string is
         #  deprecated
         def test_deprecated_format_string(obj, fmt_str, should_raise_warning):
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always", DeprecationWarning)
-                format(obj, fmt_str)
+            if sys.version_info[0] == 3 and sys.version_info[1] >= 4:
+                if should_raise_warning:
+                    self.assertRaises(TypeError, format, obj, fmt_str)
+                else:
+                    try:
+                        format(obj, fmt_str)
+                    except TypeError:
+                        self.fail('object.__format__ raised TypeError unexpectedly')
+            else:
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always", DeprecationWarning)
+                    format(obj, fmt_str)
             # Was:
             # if should_raise_warning:
             #     self.assertEqual(len(w), 1)

--- a/past/tests/test_builtins.py
+++ b/past/tests/test_builtins.py
@@ -1633,16 +1633,25 @@ class BuiltinTest(unittest.TestCase):
         # Issue #7994: object.__format__ with a non-empty format string is
         #  pending deprecated
         def test_deprecated_format_string(obj, fmt_str, should_raise_warning):
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always", PendingDeprecationWarning)
-                format(obj, fmt_str)
-            if should_raise_warning:
-                self.assertEqual(len(w), 1)
-                self.assertIsInstance(w[0].message, PendingDeprecationWarning)
-                self.assertIn('object.__format__ with a non-empty format '
-                              'string', str(w[0].message))
+            if sys.version_info[0] == 3 and sys.version_info[1] >= 4:
+                if should_raise_warning:
+                    self.assertRaises(TypeError, format, obj, fmt_str)
+                else:
+                    try:
+                        format(obj, fmt_str)
+                    except TypeError:
+                        self.fail('object.__format__ raised TypeError unexpectedly')
             else:
-                self.assertEqual(len(w), 0)
+                with warnings.catch_warnings(record=True) as w:
+                    warnings.simplefilter("always", PendingDeprecationWarning)
+                    format(obj, fmt_str)
+                if should_raise_warning:
+                    self.assertEqual(len(w), 1)
+                    self.assertIsInstance(w[0].message, PendingDeprecationWarning)
+                    self.assertIn('object.__format__ with a non-empty format '
+                                  'string', str(w[0].message))
+                else:
+                    self.assertEqual(len(w), 0)
 
         fmt_strs = ['', 's', u'', u's']
 


### PR DESCRIPTION
The test checks if this is deprecated, but in 3.4, the behaviour was made an error.
