### PR TITLE
Fix expectedFailurePY3 on 3.4.

### DIFF
--- a/future/tests/base.py
+++ b/future/tests/base.py
@@ -308,14 +308,7 @@ skip26 = unittest.skipIf(PY26, "this test is known to fail on Py2.6")
 def expectedFailurePY3(func):
     if not PY3:
         return func
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        try:
-            func(*args, **kwargs)
-        except Exception:
-            raise unittest.case._ExpectedFailure(sys.exc_info())
-        raise unittest.case._UnexpectedSuccess
-    return wrapper
+    return unittest.expectedFailure(func)
 
 
 def expectedFailurePY26(func):


### PR DESCRIPTION
As I commented on the [change](0530ef4625cc40b48b78194998e8f4a3e3e3b81f#diff-4ed1530ec045d53193bf6abe0bf29516R316), this seems to work on 3.3 and 3.4.
