### PR TITLE
Correctly mark tests that are successful on 3.x.

### DIFF
--- a/future/tests/test_builtins.py
+++ b/future/tests/test_builtins.py
@@ -9,7 +9,7 @@ from future.builtins import (bytes, dict, int, range, round, str, super,
                              filter, map, zip)
 
 from future.utils import PY3, exec_, native_str, implements_iterator
-from future.tests.base import unittest, skip26
+from future.tests.base import unittest, skip26, expectedFailurePY2
 
 import sys
 import textwrap
@@ -91,7 +91,7 @@ class TestBuiltins(unittest.TestCase):
         self.assertTrue(isinstance(u'string', str))
         self.assertFalse(isinstance(u'string', bytes))
 
-    @unittest.expectedFailure
+    @expectedFailurePY2
     def test_type(self):
         """
         The following fails when passed a unicode string on Python
@@ -855,7 +855,7 @@ class BuiltinTest(unittest.TestCase):
         self.assertEqual(list(filter(lambda x: x>=3, (1, 2, 3, 4))), [3, 4])
         self.assertRaises(TypeError, list, filter(42, (1, 2)))
 
-    @unittest.expectedFailure
+    @expectedFailurePY2
     def test_filter_pickle(self):
         f1 = filter(filter_char, "abcdeabcde")
         f2 = filter(filter_char, "abcdeabcde")
@@ -1058,7 +1058,7 @@ class BuiltinTest(unittest.TestCase):
             raise RuntimeError
         self.assertRaises(RuntimeError, list, map(badfunc, range(5)))
 
-    @unittest.expectedFailure
+    @expectedFailurePY2
     def test_map_pickle(self):
         m1 = map(map_char, "Is this the real life?")
         m2 = map(map_char, "Is this the real life?")
@@ -1425,7 +1425,7 @@ class BuiltinTest(unittest.TestCase):
         a[0] = a
         self.assertEqual(repr(a), '{0: {...}}')
 
-    @unittest.expectedFailure
+    @expectedFailurePY2
     def test_round(self):
         self.assertEqual(round(0.0), 0.0)
         # Was: self.assertEqual(type(round(0.0)), int)
@@ -1643,7 +1643,7 @@ class BuiltinTest(unittest.TestCase):
                     return i
         self.assertRaises(ValueError, list, zip(BadSeq(), BadSeq()))
 
-    @unittest.expectedFailure
+    @expectedFailurePY2
     def test_zip_pickle(self):
         a = (1, 2, 3)
         b = (4, 5, 6)

--- a/future/tests/test_bytes.py
+++ b/future/tests/test_bytes.py
@@ -8,7 +8,7 @@ from future.builtins import *
 from future import utils
 
 from numbers import Integral
-from future.tests.base import unittest
+from future.tests.base import unittest, expectedFailurePY2
 
 
 TEST_UNICODE_STR = u'ℝεα∂@ßʟ℮ ☂ℯṧт υηḯ¢☺ḓ℮'
@@ -115,7 +115,7 @@ class TestBytes(unittest.TestCase):
         self.assertEqual(b[0:1], b'A')
         self.assertEqual(b[:], b'ABCD')
 
-    @unittest.expectedFailure
+    @expectedFailurePY2
     def test_b_literal_creates_newbytes_object(self):
         """
         It would nice if the b'' literal syntax could be coaxed into producing

--- a/future/tests/test_dict.py
+++ b/future/tests/test_dict.py
@@ -6,7 +6,7 @@ Tests for the backported class:`dict` class.
 from __future__ import absolute_import, unicode_literals, print_function
 from future.builtins import *
 from future import utils
-from future.tests.base import unittest
+from future.tests.base import unittest, expectedFailurePY2
 
 import os
 import sys
@@ -87,7 +87,7 @@ class TestDict(unittest.TestCase):
         assert isinstance(d1.values() | d2.keys(), set)
         assert isinstance(d1.items() | d2.items(), set)
 
-    @unittest.expectedFailure
+    @expectedFailurePY2
     def test_braces_create_newdict_object(self):
         """
         It would nice if the {} dict syntax could be coaxed

--- a/future/tests/test_int.py
+++ b/future/tests/test_int.py
@@ -5,7 +5,7 @@ int tests from Py3.3
 from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 from future.builtins import *
-from future.tests.base import unittest
+from future.tests.base import unittest, expectedFailurePY2
 from future.utils import PY26
 
 import sys
@@ -239,7 +239,7 @@ class IntTestCases(unittest.TestCase):
         self.assertEqual(int('2br45qc', 35), 4294967297)
         self.assertEqual(int('1z141z5', 36), 4294967297)
 
-    @unittest.expectedFailure     # fails on Py2
+    @expectedFailurePY2     # fails on Py2
     @cpython_only
     def test_small_ints(self):
         # Bug #3236: Return small longs from PyLong_FromString
@@ -264,7 +264,7 @@ class IntTestCases(unittest.TestCase):
         self.assertEqual(seconds, 6000)
         self.assertTrue(isinstance(seconds, float))
 
-    @unittest.expectedFailure
+    @expectedFailurePY2
     def test_keyword_args_2(self):
         # newint causes these to fail:
         self.assertRaises(TypeError, int, base=10)
@@ -401,7 +401,7 @@ class IntTestCases(unittest.TestCase):
     
     # Exception messages in Py2 are 8-bit strings. The following fails,
     # even if the testlist strings are wrapped in str() calls...
-    @unittest.expectedFailure
+    @expectedFailurePY2
     def test_error_message(self):
         testlist = ('\xbd', '123\xbd', '  123 456  ')
         for s in testlist:

--- a/future/tests/test_super.py
+++ b/future/tests/test_super.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, division, unicode_literals
 import sys
 
-from future.tests.base import unittest
+from future.tests.base import unittest, expectedFailurePY2
 from future import utils
 from future.builtins import super
 
@@ -57,7 +57,7 @@ class TestSuper(unittest.TestCase):
         self.assertEqual(E().f(), 'ABCD')
         self.assertEqual(E.f(E()), 'ABCD')
 
-    @unittest.expectedFailure    # not working yet: infinite loop
+    @expectedFailurePY2    # not working yet: infinite loop
     def test_unbound_method_transfer_working(self):
         self.assertEqual(F().f(), 'ABCD')
         self.assertEqual(F.f(F()), 'ABCD')

--- a/future/tests/test_surrogateescape.py
+++ b/future/tests/test_surrogateescape.py
@@ -8,7 +8,7 @@ from future.builtins import (bytes, dict, int, range, round, str, super,
                              ascii, chr, hex, input, next, oct, open, pow,
                              filter, map, zip)
 from future.utils.surrogateescape import register_surrogateescape
-from future.tests.base import unittest, expectedFailurePY26
+from future.tests.base import unittest, expectedFailurePY26, expectedFailurePY2
 
 
 class TestSurrogateEscape(unittest.TestCase):
@@ -33,7 +33,7 @@ class TestSurrogateEscape(unittest.TestCase):
         b = payload.encode('ascii', 'surrogateescape')
         self.assertEqual(b, b'cMO2c3RhbA\xc3\xa1=\n')
 
-    @unittest.expectedFailure
+    @expectedFailurePY2
     def test_encode_ascii_surrogateescape_non_newstr(self):
         """
         As above but without a newstr object. Fails on Py2.
@@ -70,7 +70,7 @@ class SurrogateEscapeTest(unittest.TestCase):
         # self.assertEqual("foo\udc80bar".encode("ascii", "surrogateescape"),
         #                  b"foo\x80bar")
 
-    @unittest.expectedFailure
+    @expectedFailurePY2
     def test_charmap(self):
         # bad byte: \xa5 is unmapped in iso-8859-3
         self.assertEqual(b"foo\xa5bar".decode("iso-8859-3", "surrogateescape"),
@@ -84,7 +84,7 @@ class SurrogateEscapeTest(unittest.TestCase):
                          b"\xe4\xeb\xef\xf6\xfc")
 
     # FIXME:
-    @unittest.expectedFailure
+    @expectedFailurePY2
     def test_encoding_works_normally(self):
         """
         Test that encoding into various encodings (particularly utf-16)


### PR DESCRIPTION
These need to be marked correctly because 3.4's unittest treats unexpected successes as a failure of the entire build.

Note, in most cases, I did not check whether these tests really _should_ be successes; I just made explicit what's already happening.
