### PR TITLE
Fix for absent exception raise in Python3

### DIFF
--- a/future/utils/__init__.py
+++ b/future/utils/__init__.py
@@ -395,6 +395,7 @@ if PY3:
             exc = tp
         if exc.__traceback__ is not tb:
             raise exc.with_traceback(tb)
+        raise exc
 
     def raise_with_traceback(exc, traceback=Ellipsis):
         if traceback == Ellipsis:


### PR DESCRIPTION
Hi,

Just a tiny fix for absent exception raise in `raise_` function (Python 3 only).
