### PR TITLE
Don't override existing PYTHONPATH for tests.

### DIFF
--- a/src/future/tests/base.py
+++ b/src/future/tests/base.py
@@ -152,7 +152,11 @@ class CodeHandler(unittest.TestCase):
         """)
         self.interpreters = [sys.executable]
         self.tempdir = tempfile.mkdtemp() + os.path.sep
-        self.env = {'PYTHONPATH': os.getcwd()}
+        pypath = os.getenv('PYTHONPATH')
+        if pypath:
+            self.env = {'PYTHONPATH': os.getcwd() + os.pathsep + pypath}
+        else:
+            self.env = {'PYTHONPATH': os.getcwd()}
 
     def convert(self, code, stages=(1, 2), all_imports=False, from3=False,
                 reformat=True, run=True, conservative=False):


### PR DESCRIPTION
We can prepend some new paths at the beginning, but we don't want to lose any existing module search paths when doing so.

Should take care of the last issue in #109.
