### PR TITLE
Make html.escape handle both bytes / string.

### DIFF
--- a/src/html/__init__.py
+++ b/src/html/__init__.py
@@ -14,18 +14,22 @@ else:
 
 
     _escape_map = {ord('&'): '&amp;', ord('<'): '&lt;', ord('>'): '&gt;'}
+    _escape_map_u = {k: unicode(v) for k, v in _escape_map.items()}
     _escape_map_full = {ord('&'): '&amp;', ord('<'): '&lt;', ord('>'): '&gt;',
                         ord('"'): '&quot;', ord('\''): '&#x27;'}
-
-    # NB: this is a candidate for a bytes/string polymorphic interface
+    _escape_map_full_u = {k: unicode(v) for k, v in _escape_map_full.items()}
 
     def escape(s, quote=True):
         """
         Replace special characters "&", "<" and ">" to HTML-safe sequences.
         If the optional flag quote is true (the default), the quotation mark
-        characters, both double quote (") and single quote (') characters are also
-        translated.
+        characters, both double quote (") and single quote (') characters are
+        also translated.
         """
         if quote:
-            return s.translate(_escape_map_full)
-        return s.translate(_escape_map)
+            return s.translate(_escape_map_full
+                               if isinstance(s, str)
+                               else _escape_map_full_u)
+        return s.translate(_escape_map
+                           if isinstance(s, str)
+                           else _escape_map_u)


### PR DESCRIPTION
This fixes the bug from #108, though I'm not sure whether it handles all cases correctly?
