### PR TITLE
Fix bug where dummy_thread was always imported

### DIFF
--- a/src/_thread/__init__.py
+++ b/src/_thread/__init__.py
@@ -3,7 +3,10 @@ import sys
 __future_module__ = True
 
 if sys.version_info[0] < 3:
-    from dummy_thread import *
+    try:
+        from thread import *
+    except ImportError:
+        from dummy_thread import *
 else:
     raise ImportError('This package should not be accessible on Python 3. '
                       'Either you are trying to run from the python-future src folder '


### PR DESCRIPTION
The code always import the dummy_thread module even on platforms where the real thread module is available. This caused bugs in other packages try to import _thread in pyhton 2. 

try:
    from _thread import interrupt_main  # Py 3
except ImportError:
    from thread import interrupt_main  # Py 2

See  https://github.com/ipython/ipython/pull/7079
