### PR TITLE
Add missing import to fix OrderedDict.clear.

### DIFF
--- a/src/future/backports/misc.py
+++ b/src/future/backports/misc.py
@@ -11,7 +11,7 @@ collections.Counter      (for Python 2.6)
 from math import ceil as oldceil
 import subprocess
 
-from future.utils import iteritems, PY26
+from future.utils import iteritems, itervalues, PY26
 
 
 def ceil(x):


### PR DESCRIPTION
`OrderedDict.clear` crashes on Python 2.6. See [this](https://travis-ci.org/obspy/obspy/jobs/43326824) for example:

```
 File "/home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages/requests/packages/urllib3/_collections.py", line 89, in clear
self._container.clear()
File "/home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages/future/backports/misc.py", line 113, in clear
for node in itervalues(self.__map):

NameError: global name 'itervalues' is not defined
```

I _think_ all that needs to be done is to add the `itervalues` import to `future/backports/misc.py`, but I don't have a Py2.6 install to check. We'll see what happens on Travis...
