### PR TITLE
[DOC] Add date of release to What's new.

### DIFF
--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -5,8 +5,8 @@ What's New
 
 .. _whats-new-0.14.x:
 
-What's new in version 0.14.3
-============================
+What's new in version 0.14.3, Dec 14, 2014
+==========================================
 
 This is a bug-fix release:
 


### PR DESCRIPTION
especially on long-running projects I think it's a great practice to include the update dates so that people can see how frequently the project is enlivened.

This would have helped me while I was poking around, eg with this question;
 [DOC] URL Reference for Next steps' what_else does not resolve here in Github but is in the Doc page. #134 
AnneTheAgile