### PR TITLE
READY FOR REVIEW - Fix #144. Expand newint.__divmod__ and newint.__rdivmod__.

### DIFF
--- a/src/future/types/newint.py
+++ b/src/future/types/newint.py
@@ -201,10 +201,16 @@ class newint(with_metaclass(BaseNewInt, long)):
 
     def __divmod__(self, other):
         value = super(newint, self).__divmod__(other)
+        if value is NotImplemented:
+            mylong = long(self)
+            return (mylong // other, mylong % other)
         return (newint(value[0]), newint(value[1]))
 
     def __rdivmod__(self, other):
         value = super(newint, self).__rdivmod__(other)
+        if value is NotImplemented:
+            mylong = long(self)
+            return (other // mylong, other % mylong)
         return (newint(value[0]), newint(value[1]))
 
     def __pow__(self, other):

--- a/tests/test_future/test_int.py
+++ b/tests/test_future/test_int.py
@@ -49,6 +49,9 @@ L = [
 
 class IntTestCases(unittest.TestCase):
 
+    def setUp(self):
+        self.longMessage = True
+
     def test_isinstance_int_subclass(self):
         """
         Issue #89
@@ -453,6 +456,24 @@ class IntTestCases(unittest.TestCase):
             assert divmod(int(-x), int(y)) == divmod(-x, y)
             assert divmod(int(x), int(-y)) == divmod(x, -y)
             assert divmod(int(-x), int(-y)) == divmod(-x, -y)
+
+            assert divmod(int(x), float(y)) == divmod(x, float(y))
+            assert divmod(int(-x), float(y)) == divmod(-x, float(y))
+            assert divmod(int(x), float(-y)) == divmod(x, float(-y))
+            assert divmod(int(-x), float(-y)) == divmod(-x, float(-y))
+
+        def _frange(x, y, step):
+            _x = x ; i = 0
+            while _x < y:
+                yield _x
+                i += 1 ; _x = x + i * step
+
+        for i in range(20):
+            for d in _frange(0.005, 5.0, 0.005):
+                self.assertEqual(divmod(int(i), d), divmod(i, d), msg='i={0}; d={1}'.format(i, d))
+                self.assertEqual(divmod(int(-i), d), divmod(-i, d), msg='i={0}; d={1}'.format(i, d))
+                self.assertEqual(divmod(int(i), -d), divmod(i, -d), msg='i={0}; d={1}'.format(i, d))
+                self.assertEqual(divmod(int(-i), -d), divmod(-i, -d), msg='i={0}; d={1}'.format(i, d))
 
     def test_div(self):
         """

--- a/tests/test_future/test_int_old_division.py
+++ b/tests/test_future/test_int_old_division.py
@@ -6,7 +6,7 @@ Py2 only. int tests involving division for the case that:
 is not in effect.
 """
 
-from __future__ import (absolute_import, 
+from __future__ import (absolute_import,
                         print_function, unicode_literals)
 from future import standard_library
 from future.builtins import *
@@ -20,6 +20,10 @@ import random
 @unittest.skipIf(not PY2, 'old division tests only for Py2')
 class IntTestCasesOldDivision(unittest.TestCase):
 
+    def setUp(self):
+        self.longMessage = True
+
+
     def test_div(self):
         """
         Issue #38
@@ -27,7 +31,7 @@ class IntTestCasesOldDivision(unittest.TestCase):
         a = int(3)
         self.assertEqual(a / 5., 0.6)
         self.assertEqual(a / 5, 0)
-                                  
+
 
     def test_idiv(self):
         a = int(3)
@@ -42,7 +46,7 @@ class IntTestCasesOldDivision(unittest.TestCase):
         c /= 2.0
         self.assertEqual(c, -1.5)
         self.assertTrue(isinstance(c, float))
-                                  
+
 
     def test_truediv(self):
         """
@@ -72,6 +76,25 @@ class IntTestCasesOldDivision(unittest.TestCase):
         e /= f
         self.assertEqual(e, 0)
         self.assertTrue(isinstance(e, int))
+
+
+    def test_divmod(self):
+        """
+        Test int.__divmod__
+        """
+        vals = [10**i for i in range(0, 20)]
+        for i in range(200):
+            x = random.choice(vals)
+            y = random.choice(vals)
+            self.assertEqual(int(y).__rdivmod__(int(x)), divmod(x, y), msg='x={0}; y={1}'.format(x, y))
+            self.assertEqual(int(-y).__rdivmod__(int(x)), divmod(x, -y), msg='x={0}; y={1}'.format(x, y))
+            self.assertEqual(int(y).__rdivmod__(int(-x)), divmod(-x, y), msg='x={0}; y={1}'.format(x, y))
+            self.assertEqual(int(-y).__rdivmod__(int(-x)), divmod(-x, -y), msg='x={0}; y={1}'.format(x, y))
+
+            self.assertEqual(int(x).__rdivmod__(int(y)), long(x).__rdivmod__(y), msg='x={0}; y={1}'.format(x, y))
+            self.assertEqual(int(-x).__rdivmod__(int(y)), long(-x).__rdivmod__(y), msg='x={0}; y={1}'.format(x, y))
+            self.assertEqual(int(x).__rdivmod__(int(-y)), long(x).__rdivmod__(-y), msg='x={0}; y={1}'.format(x, y))
+            self.assertEqual(int(-x).__rdivmod__(int(-y)), long(-x).__rdivmod__(-y), msg='x={0}; y={1}'.format(x, y))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix #144. Expand newint.__divmod__ and newint.__rdivmod__ to fall back to <type 'long'> implementations where appropriate.