### PR TITLE
fixed missing http.client.HTTPMessage

### DIFF
--- a/src/http/client.py
+++ b/src/http/client.py
@@ -4,3 +4,4 @@ import sys
 assert sys.version_info[0] < 3
 
 from httplib import *
+from httplib import HTTPMessage


### PR DESCRIPTION
The latest version of urllib3 for Python2 uses http.client.HTTPMessage and without this fix it breaks when python-future is installed.