### PR TITLE
Remove duplicate assertion in builtins tests

### DIFF
--- a/tests/test_future/test_builtins.py
+++ b/tests/test_future/test_builtins.py
@@ -529,7 +529,6 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaises(TypeError, compile, 'pass', '?', 'exec',
                           mode='eval', source='0', filename='tmp')
         compile('print("\xe5")\n', '', 'exec')
-        self.assertRaises(TypeError, compile, chr(0), 'f', 'exec')
         self.assertRaises(ValueError, compile, str('a = 1'), 'f', 'bad')
 
         # test the optimize argument


### PR DESCRIPTION
The other instance of this assertion is commented out because it fails
on Python 3.5; see commit 7959135e44a35de7dff4b56dcaf86d9b74d88329
(Disable two assertions in builtins tests for Py3.5 compatibility).