### PR TITLE
READY FOR REVIEW - Fix #171. Pass `newbytes`'s native value to its parent constructor.

### DIFF
--- a/src/future/types/newbytes.py
+++ b/src/future/types/newbytes.py
@@ -9,7 +9,7 @@ from collections import Iterable
 from numbers import Integral
 import string
 
-from future.utils import istext, isbytes, PY3, with_metaclass
+from future.utils import istext, isbytes, native, PY3, with_metaclass
 from future.types import no, issubset
 from future.types.newobject import newobject
 
@@ -42,14 +42,14 @@ class newbytes(with_metaclass(BaseNewBytes, _builtin_bytes)):
         bytes(bytes_or_buffer) -> immutable copy of bytes_or_buffer
         bytes(int) -> bytes object of size given by the parameter initialized with null bytes
         bytes() -> empty bytes object
-        
+
         Construct an immutable array of bytes from:
           - an iterable yielding integers in range(256)
           - a text string encoded using the specified encoding
           - any object implementing the buffer API.
           - an integer
         """
-        
+
         encoding = None
         errors = None
 
@@ -64,7 +64,7 @@ class newbytes(with_metaclass(BaseNewBytes, _builtin_bytes)):
         # We use type() instead of the above because we're redefining
         # this to be True for all unicode string subclasses. Warning:
         # This may render newstr un-subclassable.
-        if type(args[0]) == newbytes:
+        if type(args[0]) is newbytes:
             # Special-case: for consistency with Py3.3, we return the same object
             # (with the same id) if a newbytes object is passed into the
             # newbytes constructor.
@@ -90,8 +90,8 @@ class newbytes(with_metaclass(BaseNewBytes, _builtin_bytes)):
             newargs = [encoding]
             if errors is not None:
                 newargs.append(errors)
-            value = args[0].encode(*newargs)
-            ### 
+            value = native(args[0].encode(*newargs))
+            ###
         elif isinstance(args[0], Iterable):
             if len(args[0]) == 0:
                 # This could be an empty list or tuple. Return b'' as on Py3.
@@ -113,7 +113,7 @@ class newbytes(with_metaclass(BaseNewBytes, _builtin_bytes)):
         else:
             value = args[0]
         return super(newbytes, cls).__new__(cls, value)
-        
+
     def __repr__(self):
         return 'b' + super(newbytes, self).__repr__()
 
@@ -140,7 +140,7 @@ class newbytes(with_metaclass(BaseNewBytes, _builtin_bytes)):
         else:
             newbyteskey = newbytes(key)
         return issubset(list(newbyteskey), list(self))
-    
+
     @no(unicode)
     def __add__(self, other):
         return newbytes(super(newbytes, self).__add__(other))
@@ -148,7 +148,7 @@ class newbytes(with_metaclass(BaseNewBytes, _builtin_bytes)):
     @no(unicode)
     def __radd__(self, left):
         return newbytes(left) + self
-            
+
     @no(unicode)
     def __mul__(self, other):
         return newbytes(super(newbytes, self).__mul__(other))
@@ -371,7 +371,7 @@ class newbytes(with_metaclass(BaseNewBytes, _builtin_bytes)):
         """
         Strip trailing bytes contained in the argument.
         If the argument is omitted, strip trailing ASCII whitespace.
-        """        
+        """
         return newbytes(super(newbytes, self).rstrip(bytes_to_strip))
 
     @no(unicode)
@@ -379,24 +379,24 @@ class newbytes(with_metaclass(BaseNewBytes, _builtin_bytes)):
         """
         Strip leading and trailing bytes contained in the argument.
         If the argument is omitted, strip trailing ASCII whitespace.
-        """        
+        """
         return newbytes(super(newbytes, self).strip(bytes_to_strip))
 
     def lower(self):
         """
         b.lower() -> copy of b
-        
+
         Return a copy of b with all ASCII characters converted to lowercase.
-        """        
+        """
         return newbytes(super(newbytes, self).lower())
 
     @no(unicode)
     def upper(self):
         """
         b.upper() -> copy of b
-        
+
         Return a copy of b with all ASCII characters converted to uppercase.
-        """        
+        """
         return newbytes(super(newbytes, self).upper())
 
     @classmethod

--- a/tests/test_future/test_bytes.py
+++ b/tests/test_future/test_bytes.py
@@ -29,12 +29,20 @@ class TestBytes(unittest.TestCase):
         b = bytes(u, encoding='utf-8')
         self.assertEqual(b, u.encode('utf-8'))
 
+        nu = str(u)
+        b = bytes(nu, encoding='utf-8')
+        self.assertEqual(b, u.encode('utf-8'))
+
     def test_bytes_encoding_arg_non_kwarg(self):
         """
         As above, but with a positional argument
         """
         u = u'Unicode string: \u5b54\u5b50'
         b = bytes(u, 'utf-8')
+        self.assertEqual(b, u.encode('utf-8'))
+
+        nu = str(u)
+        b = bytes(nu, 'utf-8')
         self.assertEqual(b, u.encode('utf-8'))
 
     def test_bytes_string_no_encoding(self):
@@ -290,7 +298,7 @@ class TestBytes(unittest.TestCase):
         exc = str(cm.exception)
         # self.assertIn('bytes', exc)
         # self.assertIn('tuple', exc)
-        
+
     def test_decode(self):
         b = bytes(b'abcd')
         s = b.decode('utf-8')
@@ -357,7 +365,7 @@ class TestBytes(unittest.TestCase):
         d[s] = s
         self.assertEqual(len(d), 2)
         self.assertEqual(set(d.keys()), set([s, b]))
-    
+
     @unittest.expectedFailure
     def test_hash_with_native_types(self):
         # Warning: initializing the dict with native Py2 types throws the
@@ -478,7 +486,7 @@ class TestBytes(unittest.TestCase):
         ValueError
           ...
         ValueError: bytes must be in range(0, 256)
-        
+
         Ensure our bytes() constructor has the same behaviour
         """
         b1 = bytes([254, 255])

--- a/tests/test_future/test_str.py
+++ b/tests/test_future/test_str.py
@@ -18,6 +18,7 @@ class TestStr(unittest.TestCase):
         self.assertFalse(str is bytes)
         self.assertEqual(str('blah'), u'blah')  # u'' prefix: Py3.3 and Py2 only
         self.assertEqual(str(b'1234'), "b'1234'")
+        self.assertEqual(str(bytes(b'1234')), "b'1234'")
 
     def test_bool_str(self):
         s1 = str(u'abc')
@@ -258,7 +259,7 @@ class TestStr(unittest.TestCase):
         if utils.PY2:
             self.assertTrue(b'A' in s)
         with self.assertRaises(TypeError):
-            bytes(b'A') in s                  
+            bytes(b'A') in s
         with self.assertRaises(TypeError):
             65 in s                                 # unlike bytes
 


### PR DESCRIPTION
Fix #171. Pass `newbytes`'s native value to its parent constructor.

CAVEAT: without monkey-patching Python 2's native `str`'s constructor, I do not know how to handle this case:

```py
Python 2.7.10 (default, Sep 24 2015, 10:13:45)
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> nativebytes = bytes ; nativestr = str ; from builtins import *
>>> nativebytes(bytes(b'asdf'))
"b'asdf'" # Whoops!
>>> # This means you can't pass newbytes in many contexts, such as:
>>> from urllib import urlencode
>>> urlencode({ bytes(b'a'): 1, bytes(b'b'): 2 })
'b%27a%27=1&b%27b%27=2'
>>> # :o(
```

But this works now:

```py
Python 2.7.10 (default, Sep 24 2015, 10:13:45)
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)] on darwin
>>> nativebytes = bytes ; nativestr = str ; from builtins import *
>>> bytes(str(u'asdf'), u'utf_8')
b'asdf'
```

Some things just won't work (and are not addressed by this PR). Consider:

```py
Python 2.7.10 (default, Sep 24 2015, 10:13:45)
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> nativebytes = bytes ; nativestr = str ; from builtins import *
>>> from urllib import urlencode
>>> urlencode({ bytes(b'a'): 1, bytes(b'b'): 2 }) # the bytes get double-encoded ...
'b%27a%27=1&b%27b%27=2'
>>> urlencode({ str(b'a'): 1, str(b'b'): 2 }) # ... but the strs do okay ...
'a=1&b=2'
>>> str(b'a') # ... because of this
'a'
>>> urlencode({ u'asdf': u'1' }) # this works though
'asdf=1'
>>> urlencode({ bytes(str(b'a')): 1, bytes(str(b'b')): 2 }) # as expected
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../python-future/src/future/types/newbytes.py", line 85, in __new__
    raise TypeError('unicode string argument without an encoding')
TypeError: unicode string argument without an encoding
>>> urlencode({ str(bytes(b'a')): 1, str(bytes(b'b')): 2 }) # weird, but same as Py 3
'b%27b%27=2&b%27a%27=1'
>>> str(bytes(b'a')) # this explains the immediately previous output
"b'a'"
```

Now consider:

```py
Python 3.4.3 (default, Sep  3 2015, 05:14:09)
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from urllib.parse import urlencode
>>> urlencode({ bytes(b'a'): 1, bytes(b'b'): 2 }) # now the bytes work ...
'b=2&a=1'
>>> urlencode({ str(b'a'): 1, str(b'b'): 2 }) # ... but the strs don't ...
'b%27b%27=2&b%27a%27=1'
>>> str(b'a') # ... because of this
"b'a'"
>>> urlencode({ u'asdf': u'1' }) # this works though
'asdf=1'
>>> urlencode({ bytes(str(b'a')): 1, bytes(str(b'b')): 2 }) # yup
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: string argument without an encoding
>>> urlencode({ str(bytes(b'a')): 1, str(bytes(b'b')): 2 }) # same as in Py 2
'b%27b%27=2&b%27a%27=1'
>>> str(bytes(b'a')) # same as in Py 2
"b'a'"
```

The way to fix *one* of those inconsistencies is to change `newstr`'s constructor to treat Python 2's native `str`s as `bytes`, which probably means more checking at [`future/types/newstr.py`, line 95](https://github.com/PythonCharmers/python-future/blob/v0.15.2/src/future/types/newstr.py#L95), but this might break other things.