### PR TITLE
Add more robust support for --nofix

### DIFF
--- a/src/libfuturize/main.py
+++ b/src/libfuturize/main.py
@@ -205,7 +205,27 @@ def main(args=None):
         print("Use --help to show usage.", file=sys.stderr)
         return 2
 
-    unwanted_fixes = set(fixer_pkg + ".fix_" + fix for fix in options.nofix)
+    unwanted_fixes = set()
+    for fix in options.nofix:
+        if ".fix_" in fix:
+            unwanted_fixes.add(fix)
+        else:
+            # Infer the full module name for the fixer.
+            # First ensure that no names clash (e.g.
+            # lib2to3.fixes.fix_blah and libfuturize.fixes.fix_blah):
+            found = [f for f in avail_fixes
+                     if f.endswith('fix_{0}'.format(fix))]
+            if len(found) > 1:
+                print("Ambiguous fixer name. Choose a fully qualified "
+                      "module name instead from these:\n" +
+                      "\n".join("  " + myf for myf in found),
+                      file=sys.stderr)
+                return 2
+            elif len(found) == 0:
+                print("Unknown fixer. Use --list-fixes or -l for a list.",
+                      file=sys.stderr)
+                return 2
+            unwanted_fixes.add(found[0])
 
     extra_fixes = set()
     if options.all_imports:


### PR DESCRIPTION
Currently the `--nofix` option in the `futurize` script only supports short names (i.e. not fully-qualified names) and fixers from `libfuturize`, not from `lib2to3`. This commit makes usage of `--nofix` much closer to that of `--fix`.
