### PR TITLE
Reactivate idempotency code.

### DIFF
--- a/src/future/standard_library/__init__.py
+++ b/src/future/standard_library/__init__.py
@@ -445,8 +445,8 @@ def install_aliases():
     """
     if PY3:
         return
-    # if hasattr(install_aliases, 'run_already'):
-    #     return
+    if hasattr(install_aliases, 'run_already'):
+        return
     for (newmodname, newobjname, oldmodname, oldobjname) in MOVES:
         __import__(newmodname)
         # We look up the module in sys.modules because __import__ just returns the
@@ -515,7 +515,7 @@ def install_aliases():
             dbm.ndbm = ndbm
             sys.modules['dbm.ndbm'] = ndbm
 
-    # install_aliases.run_already = True
+    install_aliases.run_already = True
 
 
 def install_hooks():


### PR DESCRIPTION
@edschofield There is currently commented code for idempotency of `standard_library.install_aliases`. This was commented out in  
https://github.com/PythonCharmers/python-future/commit/9185b01275546f5325caf36050ff7abbd61cb5fd#diff-aeef53b0591861f11a909ebbccfad0ceL497

This PR uncomments it, since it seems useful, and I couldn't find a justification for its removal. As it stands, users of libraries which use `install_aliases()` either need to check themselves whether it's been called by another library, or execute the duplicative aliasing operation for each library that uses it.
