### PR TITLE
exc not defined in this function, raise the correct error...

### DIFF
--- a/src/future/utils/surrogateescape.py
+++ b/src/future/utils/surrogateescape.py
@@ -83,7 +83,7 @@ def replace_surrogate_encode(mystring):
         # The following magic comes from Py3.3's Python/codecs.c file:
         if not 0xD800 <= code <= 0xDCFF:
             # Not a surrogate. Fail with the original exception.
-            raise exc
+            raise NotASurrogateError
         # mybytes = [0xe0 | (code >> 12),
         #            0x80 | ((code >> 6) & 0x3f),
         #            0x80 | (code & 0x3f)]

--- a/tests/test_future/test_surrogateescape.py
+++ b/tests/test_future/test_surrogateescape.py
@@ -33,6 +33,12 @@ class TestSurrogateEscape(unittest.TestCase):
         b = payload.encode('ascii', 'surrogateescape')
         self.assertEqual(b, b'cMO2c3RhbA\xc3\xa1=\n')
 
+    def test_encode_ascii_unicode(self):
+        """
+        Verify that exceptions are raised properly.
+        """
+        self.assertRaises(UnicodeEncodeError, u'\N{SNOWMAN}'.encode, 'US-ASCII', 'surrogateescape')
+
     @expectedFailurePY2
     def test_encode_ascii_surrogateescape_non_newstr(self):
         """


### PR DESCRIPTION
The exc var is not a local variable.  It clearly was suppose to be this.

Add a test to cover this case.  Verified that the new test failed before the fix, and passes after the fix.  Also, coverage shows that the line was not covered previously, and is now covered.