### PR TITLE
harcoded tmp folder prevent windows compatibilty of past module

### DIFF
--- a/src/past/translation/__init__.py
+++ b/src/past/translation/__init__.py
@@ -208,7 +208,7 @@ def detect_python2(source, pathname):
     """
     Returns a bool indicating whether we think the code is Py2
     """
-    temppath=os.environ["TMP"] if os.environ["TMP"] else '/tmp'
+    temppath=os.environ["TMP"] if os.environ["TMP"] is not None else '/tmp'
     RTs.setup_detect_python2()
     try:
         tree = RTs._rt_py2_detect.refactor_string(source, pathname)
@@ -396,7 +396,7 @@ class Py2Fixer(object):
 
                         if detect_python2(source, self.pathname):
                             source = self.transform(source)
-                            temppath = os.environ["TMP"] if os.environ["TMP"] else '/tmp'
+                            temppath = os.environ["TMP"] if os.environ["TMP"] is not None else '/tmp'
                             with open(os.path.join(temppath,'futurized_code.py'), 'w') as f:
                                 f.write('### Futurized code (from %s)\n%s' % 
                                         (self.pathname, source))

--- a/src/past/translation/__init__.py
+++ b/src/past/translation/__init__.py
@@ -208,6 +208,7 @@ def detect_python2(source, pathname):
     """
     Returns a bool indicating whether we think the code is Py2
     """
+    temppath=os.environ["TMP"] if os.environ["TMP"] else '/tmp'
     RTs.setup_detect_python2()
     try:
         tree = RTs._rt_py2_detect.refactor_string(source, pathname)
@@ -219,20 +220,20 @@ def detect_python2(source, pathname):
     if source != str(tree)[:-1]:   # remove added newline
         # The above fixers made changes, so we conclude it's Python 2 code
         logger.debug('Detected Python 2 code: {0}'.format(pathname))
-        with open('/tmp/original_code.py', 'w') as f:
+        with open(os.path.join(temppath,'original_code.py'), 'w') as f:
             f.write('### Original code (detected as py2): %s\n%s' % 
                     (pathname, source))
-        with open('/tmp/py2_detection_code.py', 'w') as f:
+        with open(os.path.join(temppath,'py2_detection_code.py'), 'w') as f:
             f.write('### Code after running py3 detection (from %s)\n%s' % 
                     (pathname, str(tree)[:-1]))
         return True
     else:
         logger.debug('Detected Python 3 code: {0}'.format(pathname))
-        with open('/tmp/original_code.py', 'w') as f:
+        with open(os.path.join(temppath,'original_code.py'), 'w') as f:
             f.write('### Original code (detected as py3): %s\n%s' % 
                     (pathname, source))
         try:
-            os.remove('/tmp/futurize_code.py')
+            os.remove(os.path.join(temppath,'futurize_code.py'))
         except OSError:
             pass
         return False
@@ -395,7 +396,8 @@ class Py2Fixer(object):
 
                         if detect_python2(source, self.pathname):
                             source = self.transform(source)
-                            with open('/tmp/futurized_code.py', 'w') as f:
+                            temppath = os.environ["TMP"] if os.environ["TMP"] else '/tmp'
+                            with open(os.path.join(temppath,'futurized_code.py'), 'w') as f:
                                 f.write('### Futurized code (from %s)\n%s' % 
                                         (self.pathname, source))
 


### PR DESCRIPTION
For issue https://github.com/PythonCharmers/python-future/issues/295
Here we are using `temp` env variable to figure out right directory to write files like `original_code.py` in past's `translate`. 
I am working on a project that rely on past module and currently before calling the past module's function I am creating Temp directory as a workaround. Once this PR is merged I don't have to use that workaround.
It would be good to make this module independent of any OS. Thanks