### PR TITLE
fixed standard_library.install_aliases() failed under SLES11SP1

### DIFF
--- a/src/future/types/newrange.py
+++ b/src/future/types/newrange.py
@@ -152,6 +152,9 @@ class range_iterator(Iterator):
     def __iter__(self):
         return self
 
+    def __next__(self):
+        return next(self._stepper)
+
     def next(self):
         return next(self._stepper)
 


### PR DESCRIPTION
When I call `standard_library.install_aliases()` under SuSE enterprise 11 sp1, it raise an exception like this:

```
# python
Python 2.6 (r26:66714, May  5 2010, 14:02:39)
[GCC 4.3.4 [gcc-4_3-branch revision 152973]] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from future import standard_library
>>> standard_library.install_aliases()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib64/python2.6/site-packages/future/standard_library/__init__.py", line 466, in install_aliases
    from future.backports.urllib import request
  File "/usr/local/lib64/python2.6/site-packages/future/backports/urllib/request.py", line 97, in <module>
    from future.backports.http import client as http_client
  File "/usr/local/lib64/python2.6/site-packages/future/backports/http/client.py", line 76, in <module>
    from future.backports.email import parser as email_parser
  File "/usr/local/lib64/python2.6/site-packages/future/backports/email/parser.py", line 15, in <module>
    from future.backports.email.feedparser import FeedParser, BytesFeedParser
  File "/usr/local/lib64/python2.6/site-packages/future/backports/email/feedparser.py", line 32, in <module>
    from future.backports.email import message
  File "/usr/local/lib64/python2.6/site-packages/future/backports/email/message.py", line 22, in <module>
    from future.backports.email._policybase import compat32
  File "/usr/local/lib64/python2.6/site-packages/future/backports/email/_policybase.py", line 14, in <module>
    from future.backports.email import header
  File "/usr/local/lib64/python2.6/site-packages/future/backports/email/header.py", line 26, in <module>
    from future.backports.email.quoprimime import _max_append, header_decode
  File "/usr/local/lib64/python2.6/site-packages/future/backports/email/quoprimime.py", line 60, in <module>
    _QUOPRI_HEADER_MAP = dict((c, '=%02X' % c) for c in range(256))
  File "/usr/local/lib64/python2.6/site-packages/future/types/newrange.py", line 143, in __iter__
    return range_iterator(self)
TypeError: Can't instantiate abstract class range_iterator with abstract methods __next__
>>>
```
