### PR TITLE
Try adding Python 3.5, 3.6, and flake8 to testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
+sudo: false
+
 language: python
 
 python:
+  - "3.6"
+  - "3.5"
   - "3.4"
   - "3.3"
   - "2.7"
   - "2.6"
 
-sudo: false
+matrix:
+  allow_failures:
+    - python: "3.5"
+    - python: "3.6"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 # These packages only exist on Ubuntu 13.04 and newer:
@@ -15,6 +22,13 @@ sudo: false
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6* ]]; then pip install -r requirements_py26.txt --use-mirrors; fi
   - python setup.py install
+
+before_script:
+  - pip install hacking  # installs flake8 and plugins
+  # stop the build if there are Python syntax errors or undefined names
+  - if [[ $TRAVIS_PYTHON_VERSION != 3.3* ]]; then flake8 . --count --exit-zero --select=E901,E999,F821,F822,F823 --show-source --statistics; fi
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  # - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 # command to run tests, e.g. python setup.py test
 


### PR DESCRIPTION
Running the tests on Python 3.5 and 3.6 in `allow_failures` mode allows us to see which tests are failing without halting the build.