### PR TITLE
Add exc to raising function.

### DIFF
--- a/src/future/utils/surrogateescape.py
+++ b/src/future/utils/surrogateescape.py
@@ -56,7 +56,7 @@ def surrogateescape_handler(exc):
             # exception anyway after this function is called, even though I think
             # it's doing what it should. It seems that the strict encoder is called
             # to encode the unicode string that this function returns ...
-            decoded = replace_surrogate_encode(mystring)
+            decoded = replace_surrogate_encode(mystring, exc)
         else:
             raise exc
     except NotASurrogateError:
@@ -68,7 +68,7 @@ class NotASurrogateError(Exception):
     pass
 
 
-def replace_surrogate_encode(mystring):
+def replace_surrogate_encode(mystring, exc):
     """
     Returns a (unicode) string, not the more logical bytes, because the codecs
     register_error functionality expects this.


### PR DESCRIPTION
This patch updates the `replace_surrogate_encode` function to also take `exc` which is the exception it tries raise to later.

Please see issue: #256 for more information.

Edit: Regarding travis, it looks the build is generally build may be failing overall?