### PR TITLE
Fix Travis CI failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ sudo: false
 # No dependencies currently unless using Python 2.6.
 
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.6* ]]; then pip install -r requirements_py26.txt --use-mirrors; fi
   - python setup.py install
 
 # command to run tests, e.g. python setup.py test


### PR DESCRIPTION
pip removed the CLI option --use-mirrors in version 7.0.0 (2015-05-22).

https://pip.pypa.io/en/stable/news/

Further, the Python 2.6 dependencies are included in setup.py, so they do not need any special treatment.