### PR TITLE
Prefer readthedocs.io instead of readthedocs.org for doc links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.intersphinx',
               'sphinx.ext.ifconfig',
               'sphinx.ext.viewcode',
-              # 'sphinxcontrib.napoleon'    # see https://readthedocs.org/projects/sphinxcontrib-napoleon/
+              # 'sphinxcontrib.napoleon'    # see https://sphinxcontrib-napoleon.readthedocs.io/
               # 'sphinx.ext.napoleon'       # use this in Sphinx 1.3+
              ]
 

--- a/docs/other/useful_links.txt
+++ b/docs/other/useful_links.txt
@@ -86,7 +86,7 @@ Buffer protocol (which bytes and bytes-like objects obey): http://docs.python.or
 
 Python's future
 ----------------
-https://ncoghlan_devs-python-notes.readthedocs.org/en/latest/python3/questions_and_answers.html
+https://ncoghlan-devs-python-notes.readthedocs.io/en/latest/python3/questions_and_answers.html
 
 http://www.ironfroggy.com/software/i-am-worried-about-the-future-of-python
 
@@ -108,4 +108,3 @@ https://pypi.python.org/pypi/awkwardduet/1.1a4
 https://github.com/campadrenalin/persei/blob/master/persei.py
 http://slideshare.net/dabeaz/mastering-python-3-io
 http://rmi.net/~lutz/strings30.html
-


### PR DESCRIPTION
Read the Docs moved hosting to readthedocs.io instead of readthedocs.org. Fix
all links in the project.

For additional details, see:

https://blog.readthedocs.com/securing-subdomains/

> Starting today, Read the Docs will start hosting projects from subdomains on
> the domain readthedocs.io, instead of on readthedocs.org. This change
> addresses some security concerns around site cookies while hosting user
> generated data on the same domain as our dashboard.