### PR TITLE
allow mixed string type inputs to misc urllib.parse.* functions

### DIFF
--- a/src/future/backports/urllib/parse.py
+++ b/src/future/backports/urllib/parse.py
@@ -107,11 +107,11 @@ def _coerce_args(*args):
     # an appropriate result coercion function
     #   - noop for str inputs
     #   - encoding function otherwise
-    str_input = isinstance(args[0], str)
+    str_input = isinstance(args[0], basestring)
     for arg in args[1:]:
         # We special-case the empty string to support the
         # "scheme=''" default argument to some functions
-        if arg and isinstance(arg, str) != str_input:
+        if arg and isinstance(arg, basestring) != str_input:
             raise TypeError("Cannot mix str and non-str arguments")
     if str_input:
         return args + (_noop,)


### PR DESCRIPTION
...eg urlparse, urlunparse, urlsplit, urlunsplit, urljoin, urldefrag, and parse_qsl.

fixes #273.

the original bug result in this kind of exception:

```
Traceback (most recent call last):
  ...
  File ".../future/backports/urllib/parse.py", line 387, in urlunparse
    _coerce_args(*components))
  File ".../future/backports/urllib/parse.py", line 115, in _coerce_args
    raise TypeError("Cannot mix str and non-str arguments")
TypeError: Cannot mix str and non-str arguments
```