### PR TITLE
Remove unused tmp files from past translation

### DIFF
--- a/src/past/translation/__init__.py
+++ b/src/past/translation/__init__.py
@@ -219,22 +219,9 @@ def detect_python2(source, pathname):
     if source != str(tree)[:-1]:   # remove added newline
         # The above fixers made changes, so we conclude it's Python 2 code
         logger.debug('Detected Python 2 code: {0}'.format(pathname))
-        with open('/tmp/original_code.py', 'w') as f:
-            f.write('### Original code (detected as py2): %s\n%s' %
-                    (pathname, source))
-        with open('/tmp/py2_detection_code.py', 'w') as f:
-            f.write('### Code after running py3 detection (from %s)\n%s' %
-                    (pathname, str(tree)[:-1]))
         return True
     else:
         logger.debug('Detected Python 3 code: {0}'.format(pathname))
-        with open('/tmp/original_code.py', 'w') as f:
-            f.write('### Original code (detected as py3): %s\n%s' %
-                    (pathname, source))
-        try:
-            os.remove('/tmp/futurize_code.py')
-        except OSError:
-            pass
         return False
 
 
@@ -395,9 +382,6 @@ class Py2Fixer(object):
 
                         if detect_python2(source, self.pathname):
                             source = self.transform(source)
-                            with open('/tmp/futurized_code.py', 'w') as f:
-                                f.write('### Futurized code (from %s)\n%s' %
-                                        (self.pathname, source))
 
                         code = compile(source, self.pathname, 'exec')
 


### PR DESCRIPTION
The /tmp/ files in past translation don't actually do anything.  Just remove them so this works with multiple users on the same machine and on windows.  

Fixes #295 #296 