### PR TITLE
Update pypi.python.org URLs to pypi.org

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -15,7 +15,7 @@
 -->
 <!--<h3>Useful Links</h3>
 <ul>
-  <li><a href="http://pypi.python.org/pypi/future">on PyPI</a></li>
+  <li><a href="https://pypi.org/project/future/">on PyPI</a></li>
   <li><a href="https://github.com/PythonCharmers/python-future">on GitHub</a></li>
 </ul>
 -->

--- a/docs/other/useful_links.txt
+++ b/docs/other/useful_links.txt
@@ -23,7 +23,7 @@ http://lucumr.pocoo.org/2011/12/7/thoughts-on-python3/
 http://python3porting.com/fixers.html
 http://washort.twistedmatrix.com/2010/11/unicode-in-python-and-how-to-prevent-it.html
 http://docs.python.org/release/3.0.1/whatsnew/3.0.html
-https://pypi.python.org/pypi/unicode-nazi
+https://pypi.org/project/unicode-nazi/
 http://www.rmi.net/~lutz/strings30.html
 
 "Porting your code to Python 3": Alexandre Vassalotti: peadrop.com/slides/mp5.pdf
@@ -43,7 +43,7 @@ python-modernize: https://github.com/mitsuhiko/python-modernize
 
 2to3 docs describing the different fixers: http://docs.python.org/2/library/2to3.html
 
-Injecting code into running Python processes (hopefully not needed): https://pypi.python.org/pypi/pyrasite/2.0
+Injecting code into running Python processes (hopefully not needed): https://pypi.org/project/pyrasite/2.0/
 
 Withdrawn PEP to help with the Py3k standard library transition: http://www.peps.io/364/
 
@@ -52,7 +52,7 @@ Import hooks
 http://www.peps.io/302/
 "Hacking Python imports ... for fun and profit": blog post from 2012-05: http://xion.org.pl/2012/05/06/hacking-python-imports/
 
-Full importlib backport to Py2: https://pypi.python.org/pypi/backport_importlib/0...1
+Full importlib backport to Py2: https://pypi.org/project/backport_importlib/0...1/
 
 Python 2.7 importlib subset: http://docs.python.org/2/whatsnew/2.7.html#importlib-section
 
@@ -78,7 +78,7 @@ PEPs: 358, 3112, 3137, 3138
 http://python3porting.com/noconv.html#unicode-section
 Unicode literals u'...' back in Python 3.3: http://www.python.org/dev/peps/pep-0414/
 https://github.com/django/django/blob/master/django/utils/encoding.py
-https://pypi.python.org/pypi/unicode-nazi
+https://pypi.org/project/unicode-nazi/
 http://docs.python.org/3/library/stdtypes.html#bytes-methods
 http://wolfprojects.altervista.org/talks/unicode-and-python-3/
 Buffer protocol (which bytes and bytes-like objects obey): http://docs.python.org/3.3/c-api/buffer.html#bufferobjects
@@ -104,7 +104,7 @@ Also: typecheck module on PyPI
 To categorize
 -------------
 
-https://pypi.python.org/pypi/awkwardduet/1.1a4
+https://pypi.org/project/awkwardduet/1.1a4/
 https://github.com/campadrenalin/persei/blob/master/persei.py
 http://slideshare.net/dabeaz/mastering-python-3-io
 http://rmi.net/~lutz/strings30.html

--- a/docs/pasteurize.rst
+++ b/docs/pasteurize.rst
@@ -30,7 +30,7 @@ classes that inherit from ``object`` on both Python versions, and both
 refer to stdlib modules (as well as builtins) under their Py3 names.
 
 Note also that the ``configparser`` module is a special case; there is a full
-backport available on PyPI (https://pypi.python.org/pypi/configparser), so, as
+backport available on PyPI (https://pypi.org/project/configparser/), so, as
 of v0.16.0, ``python-future`` no longer provides a ``configparser`` package
 alias. To use the resulting code on Py2, install the ``configparser`` backport
 with ``pip install configparser`` or by adding it to your ``requirements.txt``

--- a/docs/standard_library_imports.rst
+++ b/docs/standard_library_imports.rst
@@ -78,7 +78,7 @@ complete list is here::
     import _thread
 
 Note that, as of v0.16.0, ``python-future`` no longer includes an alias for the
-``configparser`` module because a full backport exists (see https://pypi.python.org/pypi/configparser).
+``configparser`` module because a full backport exists (see https://pypi.org/project/configparser/).
 
 .. _list-standard-library-refactored:
 

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -10,7 +10,7 @@ What's new in version 0.16.0 (2016-09-22)
 
 This release removes the ``configparser`` package as an alias for
 ``ConfigParser`` on Py2 to improve compatibility with the backported
-`configparser package <https://pypi.python.org/pypi/configparser>`. Previously
+`configparser package <https://pypi.org/project/configparser/>`. Previously
 ``python-future`` and the PyPI ``configparser`` backport clashed, causing
 various compatibility issues. (Issues #118, #181)
 


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html