### PR TITLE
Decode byte strings in sys.argv to unicode strings

### DIFF
--- a/src/future/standard_library/__init__.py
+++ b/src/future/standard_library/__init__.py
@@ -538,6 +538,8 @@ def install_hooks():
         sys.meta_path.append(newhook)
     flog.debug('sys.meta_path is now: {0}'.format(sys.meta_path))
 
+    fix_sys_argv()
+
 
 def enable_hooks():
     """
@@ -812,3 +814,10 @@ def import_top_level_modules():
                 __import__(m)
             except ImportError:     # e.g. winreg
                 pass
+
+
+def fix_sys_argv():
+    if PY3:
+        return
+
+    sys.argv = [arg.decode(sys.stdin.encoding) for arg in sys.argv]

--- a/tests/test_future/test_standard_library.py
+++ b/tests/test_future/test_standard_library.py
@@ -479,6 +479,16 @@ class TestStandardLibraryReorganization(CodeHandler):
 
         self.assertTrue('urlopen' in dir(urllib.request))
 
+    @unittest.skipIf(utils.PY3, 'fix_sys_argv test is for Py2 only')
+    def test_fix_sys_argv(self):
+        sample = u'\u042f'
+        sys.argv.append(sample.encode(sys.stdin.encoding))
+
+        standard_library.fix_sys_argv()
+        self.assertEqual(sys.argv[-1], sample)
+
+        del sys.argv[-1]
+
 
 class TestFutureMoves(CodeHandler):
     def test_future_moves_urllib_request(self):


### PR DESCRIPTION
Py3 have a list of unicode strings in `std.argv` but Py2 have a list of byte strings. Encoding is depending on a locale.

Let's decode them during `install_hooks`