### PR TITLE
Fix `past.translation` on read-only file systems

### DIFF
--- a/src/past/translation/__init__.py
+++ b/src/past/translation/__init__.py
@@ -402,9 +402,9 @@ class Py2Fixer(object):
                         code = compile(source, self.pathname, 'exec')
 
                         dirname = os.path.dirname(cachename)
-                        if not os.path.exists(dirname):
-                            os.makedirs(dirname)
                         try:
+                            if not os.path.exists(dirname):
+                                os.makedirs(dirname)
                             with open(cachename, 'wb') as f:
                                 data = marshal.dumps(code)
                                 f.write(data)


### PR DESCRIPTION
This PR solves an issue encountered with `past.translation` on a read-only file system (usecase: snap).

The code already contains a `try/except` block handling this issue for attempting to write files in the `__pycache__` directory, but the creation of `__pycache__` itself is not included in the block.

This simply moves the `os.makedirs` code to be inside the `try/except` block so that `past.translation` can work on read-only file systems.