### PR TITLE
Fixed import statements

### DIFF
--- a/docs/notebooks/Writing Python 2-3 compatible code.ipynb
+++ b/docs/notebooks/Writing Python 2-3 compatible code.ipynb
@@ -1747,7 +1747,7 @@
    "source": [
     "# Python 2 and 3: option 3\n",
     "try:\n",
-    "    import itertools.imap as map\n",
+    "    from itertools import imap as map\n",
     "except ImportError:\n",
     "    pass\n",
     "\n",
@@ -1845,7 +1845,7 @@
    "source": [
     "# Python 2 and 3: option 2\n",
     "try:\n",
-    "    import itertools.imap as map\n",
+    "    from itertools import imap as map\n",
     "except ImportError:\n",
     "    pass\n",
     "\n",


### PR DESCRIPTION
Changed `import itertools.imap as map` to `from itertools import imap as map` in two places