### PR TITLE
Fix PR #357

### DIFF
--- a/src/libfuturize/fixer_util.py
+++ b/src/libfuturize/fixer_util.py
@@ -243,7 +243,6 @@ def future_import(feature, node):
         # Is it a shebang or encoding line?
         if is_shebang_comment(node) or is_encoding_comment(node):
             shebang_encoding_idx = idx
-            continue
         if is_docstring(node):
             # skip over docstring
             continue


### PR DESCRIPTION
Turns out that comments are associated with a specific AST node in python, and are not AST nodes on their own. Therefore, "continue" after detecting the shebang comment in fact causes the future import to be placed after the first AST node, which might be anything.

- py3.7 before: `5 failed, 998 passed, 35 skipped, 46 xfailed, 18 warnings in 19.53 seconds`
- py3.7 after: `5 failed, 999 passed, 35 skipped, 46 xfailed, 18 warnings in 20.20 seconds`
- py2.7 before: `1 failed, 996 passed, 25 skipped, 62 xfailed, 1 warnings in 29.88 seconds`
- py2.7 after: `1 failed, 997 passed, 25 skipped, 62 xfailed, 1 warnings in 30.60 seconds`