### PR TITLE
Trim trailing white space throughout the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,3 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
-

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -25,4 +25,3 @@ recursive-include tests *.au
 recursive-include tests *.gif
 recursive-include tests *.py
 recursive-include tests *.txt
-

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ statements. For example, this code behaves identically on Python 2.6/2.7 after
 these imports as it does on Python 3.3+:
 
 .. code-block:: python
-    
+
     from __future__ import absolute_import, division, print_function
     from builtins import (bytes, str, open, super, range,
                           zip, round, input, int, pow, object)
@@ -93,7 +93,7 @@ these imports as it does on Python 3.3+:
 
     # Extra arguments for the open() function
     f = open('japanese.txt', encoding='utf-8', errors='replace')
-    
+
     # New zero-argument super() function:
     class VerboseList(list):
         def append(self, item):
@@ -103,15 +103,15 @@ these imports as it does on Python 3.3+:
     # New iterable range object with slicing support
     for i in range(10**15)[:10]:
         pass
-    
+
     # Other iterators: map, zip, filter
     my_iter = zip(range(3), ['a', 'b', 'c'])
     assert my_iter != list(my_iter)
-    
+
     # The round() function behaves as it does in Python 3, using
     # "Banker's Rounding" to the nearest even last digit:
     assert round(0.1250, 2) == 0.12
-    
+
     # input() replaces Py2's raw_input() (with no eval()):
     name = input('What is your name? ')
     print('Hello ' + name)
@@ -187,7 +187,7 @@ Futurize: 2 to both
 For example, running ``futurize -w mymodule.py`` turns this Python 2 code:
 
 .. code-block:: python
-    
+
     import Queue
     from urllib2 import urlopen
 
@@ -202,14 +202,14 @@ For example, running ``futurize -w mymodule.py`` turns this Python 2 code:
 into this code which runs on both Py2 and Py3:
 
 .. code-block:: python
-    
+
     from __future__ import print_function
     from future import standard_library
     standard_library.install_aliases()
     from builtins import input
     import queue
     from urllib.request import urlopen
-    
+
     def greet(name):
         print('Hello', end=' ')
         print(name)
@@ -233,14 +233,14 @@ Python 3. First install it:
 .. code-block:: bash
 
     $ pip3 install plotrique==0.2.5-7 --no-compile   # to ignore SyntaxErrors
-    
+
 (or use ``pip`` if this points to your Py3 environment.)
 
 Then pass a whitelist of module name prefixes to the ``autotranslate()`` function.
 Example:
 
 .. code-block:: bash
-    
+
     $ python3
 
     >>> from past import autotranslate
@@ -284,4 +284,3 @@ If you are new to Python-Future, check out the `Quickstart Guide
 
 For an update on changes in the latest version, see the `What's New
 <http://python-future.org/whatsnew.html>`_ page.
-

--- a/discover_tests.py
+++ b/discover_tests.py
@@ -33,14 +33,14 @@ class SkipCase(unittest.TestCase):
 def exclude_tests(suite, blacklist):
     """
     Example:
-    
+
     blacklist = [
         'test_some_test_that_should_be_skipped',
         'test_another_test_that_should_be_skipped'
     ]
     """
     new_suite = unittest.TestSuite()
-    
+
     for test_group in suite._tests:
         for test in test_group:
             if not hasattr(test, '_tests'):
@@ -55,4 +55,3 @@ def exclude_tests(suite, blacklist):
                             getattr(SkipCase(), 'skeleton_run_test'))
             new_suite.addTest(test)
     return new_suite
-

--- a/docs/3rd-party-py3k-compat-code/ipython_py3compat.py
+++ b/docs/3rd-party-py3k-compat-code/ipython_py3compat.py
@@ -41,9 +41,9 @@ def _modify_str_or_docstring(str_change_func):
         else:
             func = func_or_str
             doc = func.__doc__
-        
+
         doc = str_change_func(doc)
-        
+
         if func:
             func.__doc__ = doc
             return func
@@ -52,97 +52,97 @@ def _modify_str_or_docstring(str_change_func):
 
 if sys.version_info[0] >= 3:
     PY3 = True
-    
+
     input = input
     builtin_mod_name = "builtins"
-    
+
     str_to_unicode = no_code
     unicode_to_str = no_code
     str_to_bytes = encode
     bytes_to_str = decode
     cast_bytes_py2 = no_code
-    
+
     def isidentifier(s, dotted=False):
         if dotted:
             return all(isidentifier(a) for a in s.split("."))
         return s.isidentifier()
-    
+
     open = orig_open
-    
+
     MethodType = types.MethodType
-    
+
     def execfile(fname, glob, loc=None):
         loc = loc if (loc is not None) else glob
         exec compile(open(fname, 'rb').read(), fname, 'exec') in glob, loc
-    
+
     # Refactor print statements in doctests.
     _print_statement_re = re.compile(r"\bprint (?P<expr>.*)$", re.MULTILINE)
     def _print_statement_sub(match):
         expr = match.groups('expr')
         return "print(%s)" % expr
-    
+
     @_modify_str_or_docstring
     def doctest_refactor_print(doc):
         """Refactor 'print x' statements in a doctest to print(x) style. 2to3
         unfortunately doesn't pick up on our doctests.
-        
+
         Can accept a string or a function, so it can be used as a decorator."""
         return _print_statement_re.sub(_print_statement_sub, doc)
-    
+
     # Abstract u'abc' syntax:
     @_modify_str_or_docstring
     def u_format(s):
         """"{u}'abc'" --> "'abc'" (Python 3)
-        
+
         Accepts a string or a function, so it can be used as a decorator."""
         return s.format(u='')
 
 else:
     PY3 = False
-    
+
     input = raw_input
     builtin_mod_name = "__builtin__"
-    
+
     str_to_unicode = decode
     unicode_to_str = encode
     str_to_bytes = no_code
     bytes_to_str = no_code
     cast_bytes_py2 = cast_bytes
-    
+
     import re
     _name_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*$")
     def isidentifier(s, dotted=False):
         if dotted:
             return all(isidentifier(a) for a in s.split("."))
         return bool(_name_re.match(s))
-    
+
     class open(object):
         """Wrapper providing key part of Python 3 open() interface."""
         def __init__(self, fname, mode="r", encoding="utf-8"):
             self.f = orig_open(fname, mode)
             self.enc = encoding
-        
+
         def write(self, s):
             return self.f.write(s.encode(self.enc))
-        
+
         def read(self, size=-1):
             return self.f.read(size).decode(self.enc)
-        
+
         def close(self):
             return self.f.close()
-        
+
         def __enter__(self):
             return self
-        
+
         def __exit__(self, etype, value, traceback):
             self.f.close()
-    
+
     def MethodType(func, instance):
         return types.MethodType(func, instance, type(instance))
-    
+
     # don't override system execfile on 2.x:
     execfile = execfile
-    
+
     def doctest_refactor_print(func_or_str):
         return func_or_str
 
@@ -151,7 +151,7 @@ else:
     @_modify_str_or_docstring
     def u_format(s):
         """"{u}'abc'" --> "u'abc'" (Python 2)
-        
+
         Accepts a string or a function, so it can be used as a decorator."""
         return s.format(u='u')
 

--- a/docs/_themes/future/static/future.css_t
+++ b/docs/_themes/future/static/future.css_t
@@ -14,11 +14,11 @@
 {% set sidebar_width = '220px' %}
 {% set font_family = 'Geneva, sans serif' %}
 {% set header_font_family = 'Oxygen, ' ~ font_family %}
- 
+
 @import url("basic.css");
- 
+
 /* -- page layout ----------------------------------------------------------- */
- 
+
 body {
     font-family: {{ font_family }};
     font-size: 17px;
@@ -49,7 +49,7 @@ div.sphinxsidebar {
 hr {
     border: 1px solid #B1B4B6;
 }
- 
+
 div.body {
     background-color: #ffffff;
     color: #3E4349;
@@ -60,7 +60,7 @@ img.floatingflask {
     padding: 0 0 10px 10px;
     float: right;
 }
- 
+
 div.footer {
     width: {{ page_width }};
     margin: 20px auto 30px auto;
@@ -76,7 +76,7 @@ div.footer a {
 div.related {
     display: none;
 }
- 
+
 div.sphinxsidebar a {
     color: #444;
     text-decoration: none;
@@ -86,7 +86,7 @@ div.sphinxsidebar a {
 div.sphinxsidebar a:hover {
     border-bottom: 1px solid #999;
 }
- 
+
 div.sphinxsidebar {
     font-size: 15px;
     line-height: 1.5;
@@ -101,7 +101,7 @@ div.sphinxsidebarwrapper p.logo {
     margin: 0;
     text-align: center;
 }
- 
+
 div.sphinxsidebar h3,
 div.sphinxsidebar h4 {
     font-family: {{ font_family }};
@@ -115,7 +115,7 @@ div.sphinxsidebar h4 {
 div.sphinxsidebar h4 {
     font-size: 20px;
 }
- 
+
 div.sphinxsidebar h3 a {
     color: #444;
 }
@@ -126,7 +126,7 @@ div.sphinxsidebar p.logo a:hover,
 div.sphinxsidebar h3 a:hover {
     border: none;
 }
- 
+
 div.sphinxsidebar p {
     color: #555;
     margin: 10px 0;
@@ -137,7 +137,7 @@ div.sphinxsidebar ul {
     padding: 0;
     color: #000;
 }
- 
+
 div.sphinxsidebar input {
     border: 1px solid #ccc;
     font-family: {{ font_family }};
@@ -147,19 +147,19 @@ div.sphinxsidebar input {
 div.sphinxsidebar form.search input[name="q"] {
     width: 130px;
 }
- 
+
 /* -- body styles ----------------------------------------------------------- */
- 
+
 a {
     color: #aa0000;
     text-decoration: underline;
 }
- 
+
 a:hover {
     color: #dd0000;
     text-decoration: underline;
 }
- 
+
 div.body h1,
 div.body h2,
 div.body h3,
@@ -172,25 +172,25 @@ div.body h6 {
     padding: 0;
     color: black;
 }
- 
+
 div.body h1 { margin-top: 0; padding-top: 0; font-size: 240%; }
 div.body h2 { font-size: 180%; }
 div.body h3 { font-size: 150%; }
 div.body h4 { font-size: 130%; }
 div.body h5 { font-size: 100%; }
 div.body h6 { font-size: 100%; }
- 
+
 a.headerlink {
     color: #ddd;
     padding: 0 4px;
     text-decoration: none;
 }
- 
+
 a.headerlink:hover {
     color: #444;
     background: #eaeaea;
 }
- 
+
 div.body p, div.body dd, div.body li {
     line-height: 1.4em;
 }
@@ -237,20 +237,20 @@ div.note {
     background-color: #eee;
     border: 1px solid #ccc;
 }
- 
+
 div.seealso {
     background-color: #ffc;
     border: 1px solid #ff6;
 }
- 
+
 div.topic {
     background-color: #eee;
 }
- 
+
 p.admonition-title {
     display: inline;
 }
- 
+
 p.admonition-title:after {
     content: ":";
 }
@@ -344,7 +344,7 @@ ul, ol {
     margin: 10px 0 10px 30px;
     padding: 0;
 }
- 
+
 pre {
     background: #eee;
     padding: 7px 30px;
@@ -361,7 +361,7 @@ dl dl pre {
     margin-left: -90px;
     padding-left: 90px;
 }
- 
+
 tt {
     background-color: #E8EFF0;
     color: #222;

--- a/docs/automatic_conversion.rst
+++ b/docs/automatic_conversion.rst
@@ -27,4 +27,3 @@ mostly unchanged on both Python 2 and Python 3.
 .. include:: pasteurize.rst
 
 .. include:: conversion_limitations.rst
-

--- a/docs/bind_method.rst
+++ b/docs/bind_method.rst
@@ -9,10 +9,10 @@ from the language. To bind a method to a class compatibly across Python
 3 and Python 2, you can use the :func:`bind_method` helper function::
 
     from future.utils import bind_method
-    
+
     class Greeter(object):
         pass
-    
+
     def greet(self, message):
         print(message)
 
@@ -24,6 +24,6 @@ from the language. To bind a method to a class compatibly across Python
 
 On Python 3, calling ``bind_method(cls, name, func)`` is equivalent to
 calling ``setattr(cls, name, func)``. On Python 2 it is equivalent to::
-    
+
     import types
     setattr(cls, name, types.MethodType(func, None, cls))

--- a/docs/bytes_object.rst
+++ b/docs/bytes_object.rst
@@ -26,7 +26,7 @@ strict separation of unicode strings and byte strings as Python 3's
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
     TypeError: argument can't be unicode string
-    
+
     >>> bytes(b',').join([u'Fred', u'Bill'])
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
@@ -52,9 +52,9 @@ behaviours to Python 3's :class:`bytes`::
 Currently the easiest way to ensure identical behaviour of byte-strings
 in a Py2/3 codebase is to wrap all byte-string literals ``b'...'`` in a
 :func:`~bytes` call as follows::
-    
+
     from builtins import bytes
-    
+
     # ...
 
     b = bytes(b'This is my bytestring')
@@ -78,4 +78,3 @@ identically on Python 2.x and 3.x::
 This feature is in alpha. Please leave feedback `here
 <https://github.com/PythonCharmers/python-future/issues>`_ about whether this
 works for you.
- 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -319,7 +319,7 @@ Py3-style ``__next__`` method.
 In this example, the code defines a Py3-style iterator with a ``__next__``
 method. The ``object`` class defines a ``next`` method for Python 2 that maps
 to ``__next__``::
-    
+
     from future.builtins import object
 
     class Upper(object):
@@ -451,7 +451,7 @@ Many small improvements and fixes have been made across the project. Some highli
 - Scrubbing of the ``sys.modules`` cache performed by ``remove_hooks()`` (also
   called by the ``suspend_hooks`` and ``hooks`` context managers) is now more
   conservative.
-  
+
 ..  Is this still true?
 ..  It now removes only modules with Py3 names (such as
 ..  ``urllib.parse``) and not the corresponding ``future.standard_library.*``
@@ -530,7 +530,7 @@ is now possible on Python 2 and 3::
 
 Previously, this required manually removing ``http`` and ``http.client`` from
 ``sys.modules`` before importing ``requests`` on Python 2.x. (Issue #19)
-   
+
 This change should also improve the compatibility of the standard library hooks
 with any other module that provides its own Python 2/3 compatibility code.
 
@@ -560,7 +560,7 @@ compatibility code.
 
 There is a new ``--unicode-literals`` flag to ``futurize`` that adds the
 import::
-    
+
     from __future__ import unicode_literals
 
 to the top of each converted module. Without this flag, ``futurize`` now no
@@ -575,7 +575,7 @@ The ``pasteurize`` script for converting from Py3 to Py2/3 still adds
 Changes in version 0.11 (2014-01-28)
 ====================================
 
-There are several major new features in version 0.11. 
+There are several major new features in version 0.11.
 
 
 ``past`` package
@@ -615,10 +615,10 @@ it like this::
 
     $ pip3 install plotrique==0.2.5-7 --no-compile   # to ignore SyntaxErrors
     $ python3
-    
+
 Then pass in a whitelist of module name prefixes to the ``past.autotranslate()``
 function. Example::
-    
+
     >>> from past import autotranslate
     >>> autotranslate(['plotrique'])
     >>> import plotrique
@@ -678,7 +678,7 @@ compatibility.
 As of v0.12, importing ``future.standard_library``
 will no longer install import hooks by default. Instead, please install the
 import hooks explicitly as follows::
-    
+
     from future import standard_library
     standard_library.install_hooks()
 
@@ -721,7 +721,7 @@ If not using this context manager, it is now encouraged to add an explicit call 
 
     from future import standard_library
     standard_library.install_hooks()
-    
+
     import queue
     import html
     import http.client
@@ -754,7 +754,7 @@ over large dictionaries. For example::
 
     from __future__ import print_function
     from future.builtins import dict, range
-    
+
     squares = dict({i: i**2 for i in range(10**7)})
 
     assert not isinstance(d.items(), list)
@@ -876,7 +876,7 @@ The unused ``hacks`` module has also been removed from the source tree.
 ``isinstance()`` added to :mod:`future.builtins` (v0.8.2)
 ---------------------------------------------------------
 
-It is now possible to use ``isinstance()`` calls normally after importing ``isinstance`` from 
+It is now possible to use ``isinstance()`` calls normally after importing ``isinstance`` from
 ``future.builtins``. On Python 2, this is specially defined to be compatible with
 ``future``'s backported ``int``, ``str``, and ``bytes`` types, as well as
 handling Python 2's ``int``/``long`` distinction.
@@ -992,7 +992,7 @@ v0.8.1:
   * Move a few more safe ``futurize`` fixes from stage2 to stage1
 
   * Bug fixes to :mod:`future.utils`
-  
+
 v0.8:
   * Added Python 2.6 support
 
@@ -1080,7 +1080,7 @@ v0.3.2:
   * Added ``UserList``, ``UserString``, ``UserDict`` classes to ``collections`` module
 
   * Removed ``int`` -> ``long`` mapping
-  
+
   * Added backported ``_markupbase.py`` etc. with new-style classes to fix travis-ci build problems
 
   * Added working ``html`` and ``http.client`` backported modules

--- a/docs/compatible_idioms.rst
+++ b/docs/compatible_idioms.rst
@@ -1,5 +1,5 @@
 .. _compatible-idioms:
- 
+
 Cheat Sheet: Writing Python 2-3 compatible code
 ===============================================
 
@@ -66,7 +66,7 @@ interpreting it as a tuple:
 
     # Python 2 and 3:
     from __future__ import print_function    # (at top of module)
-    
+
     print('Hello', 'Guido')
 .. code:: python
 
@@ -76,7 +76,7 @@ interpreting it as a tuple:
 
     # Python 2 and 3:
     from __future__ import print_function
-    
+
     print('Hello', file=sys.stderr)
 .. code:: python
 
@@ -86,7 +86,7 @@ interpreting it as a tuple:
 
     # Python 2 and 3:
     from __future__ import print_function
-    
+
     print('Hello', end='')
 Raising exceptions
 ~~~~~~~~~~~~~~~~~~
@@ -116,14 +116,14 @@ Raising exceptions with a traceback:
     from six import reraise as raise_
     # or
     from future.utils import raise_
-    
+
     traceback = sys.exc_info()[2]
     raise_(ValueError, "dodgy value", traceback)
 .. code:: python
 
     # Python 2 and 3: option 2
     from future.utils import raise_with_traceback
-    
+
     raise_with_traceback(ValueError("dodgy value"))
 Exception chaining (PEP 3134):
 
@@ -145,7 +145,7 @@ Exception chaining (PEP 3134):
 
     # Python 2 and 3:
     from future.utils import raise_from
-    
+
     class FileDatabase:
         def __init__(self, filename):
             try:
@@ -199,7 +199,7 @@ Integer division (rounding down):
 
     # Python 2 and 3:
     from __future__ import division    # (at top of module)
-    
+
     assert 3 / 2 == 1.5
 "Old division" (i.e. compatible with Py2 behaviour):
 
@@ -211,7 +211,7 @@ Integer division (rounding down):
 
     # Python 2 and 3:
     from past.utils import old_div
-    
+
     a = old_div(b, c)    # always same as / on Py2
 Long integers
 ~~~~~~~~~~~~~
@@ -223,14 +223,14 @@ Short integers are gone in Python 3 and ``long`` has become ``int``
 
     # Python 2 only
     k = 9223372036854775808L
-    
+
     # Python 2 and 3:
     k = 9223372036854775808
 .. code:: python
 
     # Python 2 only
     bigint = 1L
-    
+
     # Python 2 and 3
     from builtins import int
     bigint = int(1)
@@ -241,20 +241,20 @@ To test whether a value is an integer (of any kind):
     # Python 2 only:
     if isinstance(x, (int, long)):
         ...
-    
+
     # Python 3 only:
     if isinstance(x, int):
         ...
-    
+
     # Python 2 and 3: option 1
     from builtins import int    # subclass of long on Py2
-    
+
     if isinstance(x, int):             # matches both int and long on Py2
         ...
-    
+
     # Python 2 and 3: option 2
     from past.builtins import long
-    
+
     if isinstance(x, (int, long)):
         ...
 Octal constants
@@ -282,7 +282,7 @@ Metaclasses
 
     class BaseForm(object):
         pass
-    
+
     class FormType(type):
         pass
 .. code:: python
@@ -302,7 +302,7 @@ Metaclasses
     from six import with_metaclass
     # or
     from future.utils import with_metaclass
-    
+
     class Form(with_metaclass(FormType, BaseForm)):
         pass
 Strings and bytes
@@ -320,7 +320,7 @@ prefixes:
     # Python 2 only
     s1 = 'The Zen of Python'
     s2 = u'きたないのよりきれいな方がいい\n'
-    
+
     # Python 2 and 3
     s1 = u'The Zen of Python'
     s2 = u'きたないのよりきれいな方がいい\n'
@@ -334,7 +334,7 @@ this idiom to make all string literals in a module unicode strings:
 
     # Python 2 and 3
     from __future__ import unicode_literals    # at top of module
-    
+
     s1 = 'The Zen of Python'
     s2 = 'きたないのよりきれいな方がいい\n'
 See http://python-future.org/unicode\_literals.html for more discussion
@@ -347,7 +347,7 @@ Byte-string literals
 
     # Python 2 only
     s = 'This must be a byte-string'
-    
+
     # Python 2 and 3
     s = b'This must be a byte-string'
 To loop over a byte-string with possible high-bit characters, obtaining
@@ -358,11 +358,11 @@ each character as a byte-string of length 1:
     # Python 2 only:
     for bytechar in 'byte-string with high-bit chars like \xf9':
         ...
-    
+
     # Python 3 only:
     for myint in b'byte-string with high-bit chars like \xf9':
         bytechar = bytes([myint])
-    
+
     # Python 2 and 3:
     from builtins import bytes
     for myint in bytes(b'byte-string with high-bit chars like \xf9'):
@@ -376,7 +376,7 @@ convert an int into a 1-char byte string:
     for myint in b'byte-string with high-bit chars like \xf9':
         char = chr(myint)    # returns a unicode string
         bytechar = char.encode('latin-1')
-    
+
     # Python 2 and 3:
     from builtins import bytes, chr
     for myint in bytes(b'byte-string with high-bit chars like \xf9'):
@@ -391,10 +391,10 @@ basestring
     a = u'abc'
     b = 'def'
     assert (isinstance(a, basestring) and isinstance(b, basestring))
-    
+
     # Python 2 and 3: alternative 1
     from past.builtins import basestring    # pip install future
-    
+
     a = u'abc'
     b = b'def'
     assert (isinstance(a, basestring) and isinstance(b, basestring))
@@ -402,7 +402,7 @@ basestring
 
     # Python 2 and 3: alternative 2: refactor the code to avoid considering
     # byte-strings as strings.
-    
+
     from builtins import str
     a = u'abc'
     b = b'def'
@@ -435,7 +435,7 @@ StringIO
     from StringIO import StringIO
     # or:
     from cStringIO import StringIO
-    
+
     # Python 2 and 3:
     from io import BytesIO     # for handling byte strings
     from io import StringIO    # for handling unicode strings
@@ -450,13 +450,13 @@ Suppose the package is:
         __init__.py
         submodule1.py
         submodule2.py
-        
+
 
 and the code below is in ``submodule1.py``:
 
 .. code:: python
 
-    # Python 2 only: 
+    # Python 2 only:
     import submodule2
 .. code:: python
 
@@ -505,7 +505,7 @@ Iterable dict values:
 
     # Python 2 and 3: option 1
     from builtins import dict
-    
+
     heights = dict(Fred=175, Anne=166, Joe=192)
     for key in heights.values():    # efficient on Py2 and Py3
         ...
@@ -515,7 +515,7 @@ Iterable dict values:
     from builtins import itervalues
     # or
     from six import itervalues
-    
+
     for key in itervalues(heights):
         ...
 Iterable dict items:
@@ -528,13 +528,13 @@ Iterable dict items:
 .. code:: python
 
     # Python 2 and 3: option 1
-    for (key, value) in heights.items():    # inefficient on Py2    
+    for (key, value) in heights.items():    # inefficient on Py2
         ...
 .. code:: python
 
     # Python 2 and 3: option 2
     from future.utils import viewitems
-    
+
     for (key, value) in viewitems(heights):   # also behaves like a set
         ...
 .. code:: python
@@ -543,7 +543,7 @@ Iterable dict items:
     from future.utils import iteritems
     # or
     from six import iteritems
-    
+
     for (key, value) in iteritems(heights):
         ...
 dict keys/values/items as a list
@@ -577,14 +577,14 @@ dict values as a list:
 
     # Python 2 and 3: option 2
     from builtins import dict
-    
+
     heights = dict(Fred=175, Anne=166, Joe=192)
     valuelist = list(heights.values())
 .. code:: python
 
     # Python 2 and 3: option 3
     from future.utils import listvalues
-    
+
     valuelist = listvalues(heights)
 .. code:: python
 
@@ -592,7 +592,7 @@ dict values as a list:
     from future.utils import itervalues
     # or
     from six import itervalues
-    
+
     valuelist = list(itervalues(heights))
 dict items as a list:
 
@@ -604,7 +604,7 @@ dict items as a list:
 
     # Python 2 and 3: option 2
     from future.utils import listitems
-    
+
     itemlist = listitems(heights)
 .. code:: python
 
@@ -612,7 +612,7 @@ dict items as a list:
     from future.utils import iteritems
     # or
     from six import iteritems
-    
+
     itemlist = list(iteritems(heights))
 Custom class behaviour
 ----------------------
@@ -630,7 +630,7 @@ Custom iterators
             return self._iter.next().upper()
         def __iter__(self):
             return self
-    
+
     itr = Upper('hello')
     assert itr.next() == 'H'     # Py2-style
     assert list(itr) == list('ELLO')
@@ -638,7 +638,7 @@ Custom iterators
 
     # Python 2 and 3: option 1
     from builtins import object
-    
+
     class Upper(object):
         def __init__(self, iterable):
             self._iter = iter(iterable)
@@ -646,7 +646,7 @@ Custom iterators
             return next(self._iter).upper()  # builtin next() function calls
         def __iter__(self):
             return self
-    
+
     itr = Upper('hello')
     assert next(itr) == 'H'      # compatible style
     assert list(itr) == list('ELLO')
@@ -654,7 +654,7 @@ Custom iterators
 
     # Python 2 and 3: option 2
     from future.utils import implements_iterator
-    
+
     @implements_iterator
     class Upper(object):
         def __init__(self, iterable):
@@ -663,7 +663,7 @@ Custom iterators
             return next(self._iter).upper()  # builtin next() function calls
         def __iter__(self):
             return self
-    
+
     itr = Upper('hello')
     assert next(itr) == 'H'
     assert list(itr) == list('ELLO')
@@ -678,19 +678,19 @@ Custom ``__str__`` methods
             return 'Unicode string: \u5b54\u5b50'
         def __str__(self):
             return unicode(self).encode('utf-8')
-    
+
     a = MyClass()
     print(a)    # prints encoded string
 .. code:: python
 
     # Python 2 and 3:
     from future.utils import python_2_unicode_compatible
-    
+
     @python_2_unicode_compatible
     class MyClass(object):
         def __str__(self):
             return u'Unicode string: \u5b54\u5b50'
-    
+
     a = MyClass()
     print(a)    # prints string encoded as utf-8 on Py2
 
@@ -710,20 +710,20 @@ Custom ``__nonzero__`` vs ``__bool__`` method:
             self.l = l
         def __nonzero__(self):
             return all(self.l)
-    
+
     container = AllOrNothing([0, 100, 200])
     assert not bool(container)
 .. code:: python
 
     # Python 2 and 3:
     from builtins import object
-    
+
     class AllOrNothing(object):
         def __init__(self, l):
             self.l = l
         def __bool__(self):
             return all(self.l)
-    
+
     container = AllOrNothing([0, 100, 200])
     assert not bool(container)
 Lists versus iterators
@@ -766,21 +766,21 @@ range
 
     # Python 2 and 3: forward-compatible: option 2
     from builtins import range
-    
+
     mylist = list(range(5))
     assert mylist == [0, 1, 2, 3, 4]
 .. code:: python
 
     # Python 2 and 3: option 3
     from future.utils import lrange
-    
+
     mylist = lrange(5)
     assert mylist == [0, 1, 2, 3, 4]
 .. code:: python
 
     # Python 2 and 3: backward compatible
     from past.builtins import range
-    
+
     mylist = range(5)
     assert mylist == [0, 1, 2, 3, 4]
 map
@@ -801,7 +801,7 @@ map
 
     # Python 2 and 3: option 2
     from builtins import map
-    
+
     mynewlist = list(map(f, myoldlist))
     assert mynewlist == [f(x) for x in myoldlist]
 .. code:: python
@@ -811,21 +811,21 @@ map
         import itertools.imap as map
     except ImportError:
         pass
-    
+
     mynewlist = list(map(f, myoldlist))    # inefficient on Py2
     assert mynewlist == [f(x) for x in myoldlist]
 .. code:: python
 
     # Python 2 and 3: option 4
     from future.utils import lmap
-    
+
     mynewlist = lmap(f, myoldlist)
     assert mynewlist == [f(x) for x in myoldlist]
 .. code:: python
 
     # Python 2 and 3: option 5
     from past.builtins import map
-    
+
     mynewlist = map(f, myoldlist)
     assert mynewlist == [f(x) for x in myoldlist]
 imap
@@ -835,7 +835,7 @@ imap
 
     # Python 2 only:
     from itertools import imap
-    
+
     myiter = imap(func, myoldlist)
     assert isinstance(myiter, iter)
 .. code:: python
@@ -847,7 +847,7 @@ imap
 
     # Python 2 and 3: option 1
     from builtins import map
-    
+
     myiter = map(func, myoldlist)
     assert isinstance(myiter, iter)
 .. code:: python
@@ -857,14 +857,14 @@ imap
         import itertools.imap as map
     except ImportError:
         pass
-    
+
     myiter = map(func, myoldlist)
     assert isinstance(myiter, iter)
 .. code:: python
 
     # Python 2 and 3: option 3
     from six.moves import map
-    
+
     myiter = map(func, myoldlist)
     assert isinstance(myiter, iter)
 
@@ -890,13 +890,13 @@ File IO with open()
     f = open('myfile.txt')
     data = f.read()              # as a byte string
     text = data.decode('utf-8')
-    
+
     # Python 2 and 3: alternative 1
     from io import open
     f = open('myfile.txt', 'rb')
     data = f.read()              # as bytes
     text = data.decode('utf-8')  # unicode, not bytes
-    
+
     # Python 2 and 3: alternative 2
     from io import open
     f = open('myfile.txt', encoding='utf-8')
@@ -912,7 +912,7 @@ reduce()
 
     # Python 2 and 3:
     from functools import reduce
-    
+
     assert reduce(lambda x, y: x+y, [1, 2, 3, 4, 5]) == 1+2+3+4+5
 raw\_input()
 ~~~~~~~~~~~~
@@ -926,7 +926,7 @@ raw\_input()
 
     # Python 2 and 3:
     from builtins import input
-    
+
     name = input('What is your name? ')
     assert isinstance(name, str)    # native str on Py2 and Py3
 input()
@@ -954,7 +954,7 @@ file()
 
     # Python 2 and 3:
     f = open(pathname)
-    
+
     # But preferably, use this:
     from io import open
     f = open(pathname, 'rb')   # if f.read() should return bytes
@@ -998,13 +998,13 @@ execfile()
 
     # Python 2 and 3: alternative 1
     from past.builtins import execfile
-    
+
     execfile('myfile.py')
 .. code:: python
 
     # Python 2 and 3: alternative 2
     exec(compile(open('myfile.py').read()))
-    
+
     # This can sometimes cause this:
     #     SyntaxError: function ... uses import * and bare exec ...
     # See https://github.com/PythonCharmers/python-future/issues/37
@@ -1098,7 +1098,7 @@ chr()
 
     # Python 2 and 3: option 1
     from builtins import chr
-    
+
     assert chr(64).encode('latin-1') == b'@'
     assert chr(0xc8).encode('latin-1') == b'\xc8'
 .. code:: python
@@ -1110,7 +1110,7 @@ chr()
 
     # Python 2 and 3: option 2
     from builtins import bytes
-    
+
     assert bytes([64]) == b'@'
     assert bytes([0xc8]) == b'\xc8'
 cmp()
@@ -1156,22 +1156,22 @@ dbm modules
     import dbm
     import dumbdbm
     import gdbm
-    
+
     # Python 2 and 3: alternative 1
     from future import standard_library
     standard_library.install_aliases()
-    
+
     import dbm
     import dbm.ndbm
     import dbm.dumb
     import dbm.gnu
-    
+
     # Python 2 and 3: alternative 2
     from future.moves import dbm
     from future.moves.dbm import dumb
     from future.moves.dbm import ndbm
     from future.moves.dbm import gnu
-    
+
     # Python 2 and 3: alternative 3
     from six.moves import dbm_gnu
     # (others not supported)
@@ -1182,11 +1182,11 @@ commands / subprocess modules
 
     # Python 2 only
     from commands import getoutput, getstatusoutput
-    
+
     # Python 2 and 3
     from future import standard_library
     standard_library.install_aliases()
-    
+
     from subprocess import getoutput, getstatusoutput
 subprocess.check\_output()
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1195,14 +1195,14 @@ subprocess.check\_output()
 
     # Python 2.7 and above
     from subprocess import check_output
-    
+
     # Python 2.6 and above: alternative 1
     from future.moves.subprocess import check_output
-    
+
     # Python 2.6 and above: alternative 2
     from future import standard_library
     standard_library.install_aliases()
-    
+
     from subprocess import check_output
 collections: Counter and OrderedDict
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1211,14 +1211,14 @@ collections: Counter and OrderedDict
 
     # Python 2.7 and above
     from collections import Counter, OrderedDict
-    
+
     # Python 2.6 and above: alternative 1
     from future.moves.collections import Counter, OrderedDict
-    
+
     # Python 2.6 and above: alternative 2
     from future import standard_library
     standard_library.install_aliases()
-    
+
     from collections import Counter, OrderedDict
 StringIO module
 ~~~~~~~~~~~~~~~
@@ -1245,7 +1245,7 @@ http module
     import BaseHTTPServer
     import SimpleHTTPServer
     import CGIHttpServer
-    
+
     # Python 2 and 3 (after ``pip install future``):
     import http.client
     import http.cookies
@@ -1259,14 +1259,14 @@ xmlrpc module
     # Python 2 only:
     import DocXMLRPCServer
     import SimpleXMLRPCServer
-    
+
     # Python 2 and 3 (after ``pip install future``):
     import xmlrpc.server
 .. code:: python
 
     # Python 2 only:
     import xmlrpclib
-    
+
     # Python 2 and 3 (after ``pip install future``):
     import xmlrpc.client
 html escaping and entities
@@ -1276,13 +1276,13 @@ html escaping and entities
 
     # Python 2 and 3:
     from cgi import escape
-    
+
     # Safer (Python 2 and 3, after ``pip install future``):
     from html import escape
-    
+
     # Python 2 only:
     from htmlentitydefs import codepoint2name, entitydefs, name2codepoint
-    
+
     # Python 2 and 3 (after ``pip install future``):
     from html.entities import codepoint2name, entitydefs, name2codepoint
 html parsing
@@ -1292,10 +1292,10 @@ html parsing
 
     # Python 2 only:
     from HTMLParser import HTMLParser
-    
+
     # Python 2 and 3 (after ``pip install future``)
     from html.parser import HTMLParser
-    
+
     # Python 2 and 3 (alternative 2):
     from future.moves.html.parser import HTMLParser
 urllib module
@@ -1321,7 +1321,7 @@ You may like to use Requests (http://python-requests.org) instead.
     # Python 2 and 3: easiest option
     from future.standard_library import install_aliases
     install_aliases()
-    
+
     from urllib.parse import urlparse, urlencode
     from urllib.request import urlopen, Request
     from urllib.error import HTTPError
@@ -1329,7 +1329,7 @@ You may like to use Requests (http://python-requests.org) instead.
 
     # Python 2 and 3: alternative 2
     from future.standard_library import hooks
-    
+
     with hooks():
         from urllib.parse import urlparse, urlencode
         from urllib.request import urlopen, Request
@@ -1366,9 +1366,9 @@ Tkinter
     import FileDialog
     import ScrolledText
     import SimpleDialog
-    import Tix  
+    import Tix
     import Tkconstants
-    import Tkdnd   
+    import Tkdnd
     import tkColorChooser
     import tkCommonDialog
     import tkFileDialog
@@ -1376,7 +1376,7 @@ Tkinter
     import tkMessageBox
     import tkSimpleDialog
     import ttk
-    
+
     # Python 2 and 3 (after ``pip install future``):
     import tkinter
     import tkinter.dialog
@@ -1400,7 +1400,7 @@ socketserver
 
     # Python 2 only:
     import SocketServer
-    
+
     # Python 2 and 3 (after ``pip install future``):
     import socketserver
 copy\_reg, copyreg
@@ -1410,7 +1410,7 @@ copy\_reg, copyreg
 
     # Python 2 only:
     import copy_reg
-    
+
     # Python 2 and 3 (after ``pip install future``):
     import copyreg
 configparser
@@ -1420,7 +1420,7 @@ configparser
 
     # Python 2 only:
     from ConfigParser import ConfigParser
-    
+
     # Python 2 and 3 (after ``pip install configparser``):
     from configparser import ConfigParser
 queue
@@ -1430,7 +1430,7 @@ queue
 
     # Python 2 only:
     from Queue import Queue, heapq, deque
-    
+
     # Python 2 and 3 (after ``pip install future``):
     from queue import Queue, heapq, deque
 repr, reprlib
@@ -1440,7 +1440,7 @@ repr, reprlib
 
     # Python 2 only:
     from repr import aRepr, repr
-    
+
     # Python 2 and 3 (after ``pip install future``):
     from reprlib import aRepr, repr
 UserDict, UserList, UserString
@@ -1452,16 +1452,16 @@ UserDict, UserList, UserString
     from UserDict import UserDict
     from UserList import UserList
     from UserString import UserString
-    
+
     # Python 3 only:
     from collections import UserDict, UserList, UserString
-    
+
     # Python 2 and 3: alternative 1
     from future.moves.collections import UserDict, UserList, UserString
-    
+
     # Python 2 and 3: alternative 2
     from six.moves import UserDict, UserList, UserString
-    
+
     # Python 2 and 3: alternative 3
     from future.standard_library import install_aliases
     install_aliases()
@@ -1473,16 +1473,16 @@ itertools: filterfalse, zip\_longest
 
     # Python 2 only:
     from itertools import ifilterfalse, izip_longest
-    
+
     # Python 3 only:
     from itertools import filterfalse, zip_longest
-    
+
     # Python 2 and 3: alternative 1
     from future.moves.itertools import filterfalse, zip_longest
-    
+
     # Python 2 and 3: alternative 2
     from six.moves import filterfalse, zip_longest
-    
+
     # Python 2 and 3: alternative 3
     from future.standard_library import install_aliases
     install_aliases()

--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -24,4 +24,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -9,17 +9,17 @@ The software is distributed under an MIT licence. The text is as follows
 (from ``LICENSE.txt``)::
 
     Copyright (c) 2013-2016 Python Charmers Pty Ltd, Australia
-    
+
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
     in the Software without restriction, including without limitation the rights
     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
     copies of the Software, and to permit persons to whom the Software is
     furnished to do so, subject to the following conditions:
-    
+
     The above copyright notice and this permission notice shall be included in
     all copies or substantial portions of the Software.
-    
+
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -112,4 +112,3 @@ Other Credits
 
 - ``past.translation`` is inspired by and borrows some code from Sanjay Vinip's
   ``uprefix`` module.
-

--- a/docs/custom_iterators.rst
+++ b/docs/custom_iterators.rst
@@ -14,7 +14,7 @@ would on Python 3. On Python 2, ``object`` then refers to the
 method that calls your ``__next__``. Use it as follows::
 
     from builtins import object
-    
+
     class Upper(object):
         def __init__(self, iterable):
             self._iter = iter(iterable)
@@ -92,4 +92,3 @@ the iterator as follows::
             return self
 
 On Python 3, as usual, this decorator does nothing.
-

--- a/docs/dev_notes.rst
+++ b/docs/dev_notes.rst
@@ -19,5 +19,3 @@ TODO: Check out these:
 Not available on Py2.6:
   unittest2 -> unittest?
   buffer -> memoryview?
-
-

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -11,12 +11,9 @@ The easiest way to start developing ``python-future`` is as follows:
 
     conda install -n future2 python=2.7 pip
     conda install -n future3 python=3.3 pip
-    
-    git clone https://github.com/PythonCharmers/python-future 
+
+    git clone https://github.com/PythonCharmers/python-future
 
 3. If you are using Anaconda Python distribution, this comes without a ``test``
 module on Python 2.x. Copy ``Python-2.7.6/Lib/test`` from the Python source tree
 to ``~/anaconda/envs/yourenvname/lib/python2.7/site-packages/`.
-
-
-

--- a/docs/dict_object.rst
+++ b/docs/dict_object.rst
@@ -10,7 +10,7 @@ methods which return memory-efficient set-like iterator objects, not lists.
 If your dictionaries are small, performance is not critical, and you don't need
 the set-like behaviour of iterator objects from Python 3, you can of course
 stick with standard Python 3 code in your Py2/3 compatible codebase::
-    
+
     # Assuming d is a native dict ...
 
     for key in d:
@@ -18,7 +18,7 @@ stick with standard Python 3 code in your Py2/3 compatible codebase::
 
     for item in d.items():
         # code here
-    
+
     for value in d.values():
         # code here
 
@@ -34,12 +34,12 @@ dictionaries. For example::
 
     from __future__ import print_function
     from builtins import dict, range
-    
+
     # Memory-efficient construction:
     d = dict((i, i**2) for i in range(10**7))
-    
+
     assert not isinstance(d.items(), list)
-    
+
     # Because items() is memory-efficient, so is this:
     d2 = dict((v, k) for (k, v) in d.items())
 
@@ -82,11 +82,11 @@ The memory-efficient (and CPU-efficient) alternatives are:
 
     for (key, value) in viewitems(hugedictionary):
         # some code here
-    
+
     # Set intersection:
     d = {i**2: i for i in range(1000)}
     both = viewkeys(d) & set(range(0, 1000, 7))
-     
+
     # Set union:
     both = viewvalues(d1) | viewvalues(d2)
 
@@ -94,4 +94,3 @@ For Python 2.6 compatibility, the functions ``iteritems`` etc. are also
 available in :mod:`future.utils`. These are equivalent to the functions of the
 same names in ``six``, which is equivalent to calling the ``iteritems`` etc.
 methods on Python 2, or to calling ``items`` etc. on Python 3.
-

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -33,7 +33,7 @@ and powerful new features like the `asyncio
 .. Unicode handling is also much easier. For example, see `this page
 .. <http://pythonhosted.org/kitchen/unicode-frustrations.html>`_
 .. describing some of the problems with handling Unicode on Python 2 that
-.. Python 3 mostly solves. 
+.. Python 3 mostly solves.
 
 
 Porting philosophy
@@ -143,10 +143,10 @@ version 2.0.
 ..
     Are there any example of Python 2 packages ported to Python 3 using ``future`` and ``futurize``?
     ------------------------------------------------------------------------------------------------
-    
+
     Yes, an example is the port of ``xlwt``, available `here
     <https://github.com/python-excel/xlwt/pull/32>`_.
-    
+
     The code also contains backports for several Py3 standard library
     modules under ``future/standard_library/``.
 
@@ -189,12 +189,12 @@ Can I maintain a Python 2 codebase and use 2to3 to automatically convert to Pyth
 
 This was originally the approach recommended by Python's core developers,
 but it has some large drawbacks:
-    
+
 1. First, your actual working codebase will be stuck with Python 2's
 warts and smaller feature set for as long as you need to retain Python 2
 compatibility. This may be at least 5 years for many projects, possibly
 much longer.
-    
+
 2. Second, this approach carries the significant disadvantage that you
 cannot apply patches submitted by Python 3 users against the
 auto-generated Python 3 code. (See `this talk
@@ -237,7 +237,7 @@ What is the relationship between ``python-future`` and ``python-modernize``?
 ``python-future`` contains, in addition to the ``future`` compatibility
 package, a ``futurize`` script that is similar to ``python-modernize.py``
 in intent and design. Both are based heavily on ``2to3``.
-    
+
 Whereas ``python-modernize`` converts Py2 code into a common subset of
 Python 2 and 3, with ``six`` as a run-time dependency, ``futurize``
 converts either Py2 or Py3 code into (almost) standard Python 3 code,
@@ -314,4 +314,3 @@ Where is the repo?
 ------------------
 
 `<https://github.com/PythonCharmers/python-future>`_.
-

--- a/docs/future-builtins.rst
+++ b/docs/future-builtins.rst
@@ -15,4 +15,3 @@ The ``future.builtins`` module is also accessible as ``builtins`` on Py2.
 
     >>> from builtins import round
     >>> assert round(0.1250, 2) == 0.12
-

--- a/docs/futurize.rst
+++ b/docs/futurize.rst
@@ -317,5 +317,3 @@ The next step would be manually tweaking the code to re-enable Python 2
 compatibility with the help of the ``future`` package. For example, you can add
 the ``@python_2_unicode_compatible`` decorator to any classes that define custom
 ``__str__`` methods. See :ref:`what-else` for more info.
-
-

--- a/docs/futurize_cheatsheet.rst
+++ b/docs/futurize_cheatsheet.rst
@@ -16,7 +16,7 @@ a. Clone the package from github/bitbucket. Optionally rename your repo to ``pac
 b. Create and activate a Python 2 conda environment or virtualenv. Install the package with ``python setup.py install`` and run its test suite on Py2.7 or Py2.6 (e.g. ``python setup.py test`` or ``py.test`` or ``nosetests``)
 c. Optionally: if there is a ``.travis.yml`` file, add Python version 3.6 and remove any versions < 2.6.
 d. Install Python 3 with e.g. ``sudo apt-get install python3``. On other platforms, an easy way is to use `Miniconda <http://repo.continuum.io/miniconda/index.html>`_. Then e.g.::
-    
+
     conda create -n py36 python=3.6 pip
 
 .. _porting-step1:
@@ -27,9 +27,9 @@ Step 1: modern Py2 code
 The goal for this step is to modernize the Python 2 code without introducing any dependencies (on ``future`` or e.g. ``six``) at this stage.
 
 **1a**. Install ``future`` into the virtualenv using::
-      
+
           pip install future
-  
+
 **1b**. Run ``futurize --stage1 -w *.py subdir1/*.py subdir2/*.py``. Note that with
 recursive globbing in ``bash`` or ``zsh``, you can apply stage 1 to all Python
 source files recursively with::
@@ -49,7 +49,7 @@ Example error
 One relatively common error after conversion is::
 
     Traceback (most recent call last):
-      ... 
+      ...
       File "/home/user/Install/BleedingEdge/reportlab/tests/test_encrypt.py", line 19, in <module>
         from .test_pdfencryption import parsedoc
     ValueError: Attempted relative import in non-package
@@ -110,7 +110,7 @@ Python 3 semantics on Python 2, invoke it like this::
 
     futurize --stage2 --all-imports myfolder/*.py
 
-   
+
 **2b**. Re-run your tests on Py3 now. Make changes until your tests pass on Python 3.
 
 **2c**. Commit your changes! :)

--- a/docs/hindsight.rst
+++ b/docs/hindsight.rst
@@ -1,4 +1,3 @@
 In a perfect world, the new metaclass syntax should ideally be available in
 Python 2 as a `__future__`` import like ``from __future__ import
 new_metaclass_syntax``.
-

--- a/docs/imports.rst
+++ b/docs/imports.rst
@@ -44,7 +44,7 @@ at the top of every module::
     from builtins import *
 
 On Python 3, this has no effect. (It shadows builtins with globals of the same
-names.) 
+names.)
 
 On Python 2, this import line shadows 18 builtins (listed below) to
 provide their Python 3 semantics.
@@ -59,7 +59,7 @@ Explicit forms of the imports are often preferred and are necessary for using
 certain automated code-analysis tools.
 
 The complete set of imports of builtins from ``future`` is::
-    
+
     from builtins import (ascii, bytes, chr, dict, filter, hex, input,
                           int, map, next, oct, open, pow, range, round,
                           str, super, zip)
@@ -84,7 +84,7 @@ The internal API is currently as follows::
 
 Please note that this internal API is evolving and may not be stable between
 different versions of ``future``. To understand the details of the backported
-builtins on Python 2, see the docs for these modules. 
+builtins on Python 2, see the docs for these modules.
 
 For more information on what the backported types provide, see :ref:`what-else`.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,4 +7,3 @@ codebase to support both Python 2 and Python 3 with minimal overhead.
 
 
 .. include:: contents.rst.inc
-

--- a/docs/int_object.rst
+++ b/docs/int_object.rst
@@ -66,4 +66,3 @@ Without ``future`` (or with ``future`` < 0.7), this might be::
             return list(map(int, data))   # same as returning data, but with up-front typechecking
         else:
             return list(map(long, data))
-

--- a/docs/isinstance.rst
+++ b/docs/isinstance.rst
@@ -4,7 +4,7 @@ isinstance
 ----------
 
 The following tests all pass on Python 3::
-    
+
     >>> assert isinstance(2**62, int)
     >>> assert isinstance(2**63, int)
     >>> assert isinstance(b'my byte-string', bytes)
@@ -81,7 +81,7 @@ to use it. (The output showing is from Py2)::
     100000000000000000000L
     >>> type(native(a))
     long
-    
+
     >>> b = bytes(b'ABC')
     >>> type(b)
     future.types.newbytes.newbytes
@@ -89,7 +89,7 @@ to use it. (The output showing is from Py2)::
     'ABC'
     >>> type(native(b))
     str
-    
+
     >>> s = str(u'ABC')
     >>> type(s)
     future.types.newstr.newstr
@@ -115,4 +115,3 @@ The objects ``native_str`` and ``native_bytes`` are available in
 
 The functions ``native_str_to_bytes`` and ``bytes_to_native_str`` are also
 available for more explicit conversions.
-

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -1,4 +1,3 @@
-
 limitations of the ``future`` module and differences between Py2 and Py3 that are not (yet) handled
 ===================================================================================================
 
@@ -39,7 +38,7 @@ Also:
 
       b'\x00'[0] != 0
       b'\x01'[0] != 1
-  
+
   ``futurize`` does not yet wrap all byte-string literals in a ``bytes()``
   call. This is on the to-do list. See :ref:`bytes-object` for more information.
 
@@ -51,5 +50,3 @@ Notes
   adds this back in automatically, but ensure you do this too
   when writing your classes, otherwise weird breakage when e.g. calling
   ``super()`` may occur.
-
-

--- a/docs/metaclasses.rst
+++ b/docs/metaclasses.rst
@@ -5,16 +5,14 @@ Python 3 and Python 2 syntax for metaclasses are incompatible.
 ``future`` provides a function (from ``jinja2/_compat.py``) called
 :func:`with_metaclass` that can assist with specifying metaclasses
 portably across Py3 and Py2. Use it like this::
-        
+
     from future.utils import with_metaclass
 
     class BaseForm(object):
         pass
-    
+
     class FormType(type):
         pass
-    
+
     class Form(with_metaclass(FormType, BaseForm)):
         pass
-
-

--- a/docs/older_interfaces.rst
+++ b/docs/older_interfaces.rst
@@ -22,7 +22,7 @@ robust, at the cost of less idiomatic code. Use it as follows::
 
 If you wish to achieve the effect of a two-level import such as this::
 
-    import http.client 
+    import http.client
 
 portably on both Python 2 and Python 3, note that Python currently does not
 support syntax like this::
@@ -61,7 +61,7 @@ The functional interface is to use the ``import_`` and ``from_import``
 functions from ``future.standard_library`` as follows::
 
     from future.standard_library import import_, from_import
-    
+
     http = import_('http.client')
     urllib = import_('urllib.request')
 
@@ -120,12 +120,12 @@ active for the life of a process unless removed.)
 .. importing the ``future.moves`` or ``future.backports`` modules unintentionally.
 .. Code such as this will then fall through to using the Py2 standard library
 .. modules on Py2::
-.. 
+..
 ..     try:
 ..         from http.client import HTTPConnection
 ..     except ImportError:
 ..         from httplib import HTTPConnection
-.. 
+..
 .. **Requests**: The above snippet is from the `requests
 .. <http://docs.python-requests.org>`_ library. As of v0.12, the
 .. ``future.standard_library`` import hooks are compatible with Requests.
@@ -133,11 +133,9 @@ active for the life of a process unless removed.)
 
 .. If you wish to avoid changing every reference of ``http.client`` to
 .. ``http_client`` in your code, an alternative is this::
-.. 
+..
 ..     from future.standard_library import http
 ..     from future.standard_library.http import client as _client
 ..     http.client = client
 
 .. but it has the advantage that it can be used by automatic translation scripts such as ``futurize`` and ``pasteurize``.
-
-

--- a/docs/open_function.rst
+++ b/docs/open_function.rst
@@ -5,7 +5,7 @@ open()
 
 The Python 3 builtin :func:`open` function for opening files returns file
 contents as (unicode) strings unless the binary (``b``) flag is passed, as in::
-    
+
     open(filename, 'rb')
 
 in which case its methods like :func:`read` return Py3 :class:`bytes` objects.
@@ -37,4 +37,3 @@ cast it explicitly as follows::
     assert data[4] == 13     # integer
     # Raises TypeError:
     # data + u''
-

--- a/docs/other/lessons.txt
+++ b/docs/other/lessons.txt
@@ -30,7 +30,7 @@ Python 2:
 Python 3:
 	>>> array.array(b'b')
 	TypeError: must be a unicode character, not bytes
-	
+
 	>>> array.array(u'b')
 	array('b')
 
@@ -47,5 +47,3 @@ Running test_bytes.py from Py3 on Py2 (after fixing imports) gives this:
 Ran 203 tests in 0.209s
 
 FAILED (failures=31, errors=55, skipped=1)
-
-

--- a/docs/other/upload_future_docs.sh
+++ b/docs/other/upload_future_docs.sh
@@ -21,4 +21,3 @@ unzip -o ~/python-future-html-docs.zip
 chmod a+r * html/* html/_static/*
 cp ~/cheatsheet.pdf ./html/compatible_idioms.pdf
 cp ~/cheatsheet.pdf ./html/cheatsheet.pdf
-

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -1,2 +1,1 @@
 .. include:: ../README.rst
-

--- a/docs/pasteurize.rst
+++ b/docs/pasteurize.rst
@@ -4,20 +4,20 @@
 ----------------------------
 
 Running ``pasteurize -w mypy3module.py`` turns this Python 3 code::
-    
+
     import configparser
     import copyreg
-    
+
     class Blah:
         pass
     print('Hello', end=None)
 
 into this code which runs on both Py2 and Py3::
-    
+
     from __future__ import print_function
     from future import standard_library
     standard_library.install_hooks()
-    
+
     import configparser
     import copyreg
 
@@ -26,7 +26,7 @@ into this code which runs on both Py2 and Py3::
     print('Hello', end=None)
 
 Notice that both ``futurize`` and ``pasteurize`` create explicit new-style
-classes that inherit from ``object`` on both Python versions, and both 
+classes that inherit from ``object`` on both Python versions, and both
 refer to stdlib modules (as well as builtins) under their Py3 names.
 
 Note also that the ``configparser`` module is a special case; there is a full
@@ -43,5 +43,3 @@ file.
 - extended tuple unpacking (PEP 3132)
 
 To handle function annotations (PEP 3107), see :ref:`func_annotations`.
-
-

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -66,7 +66,7 @@ module::
 
     from future import standard_library
     standard_library.install_aliases()
-    
+
 and converts several Python 3-only constructs (like keyword-only arguments) to a
 form compatible with both Py3 and Py2. Most remaining Python 3 code should
 simply work on Python 2.
@@ -93,7 +93,7 @@ Standard library reorganization
 :mod:`future` supports the standard library reorganization (PEP 3108) via
 one of several mechanisms, allowing most moved standard library modules
 to be accessed under their Python 3 names and locations in Python 2::
-    
+
     from future import standard_library
     standard_library.install_aliases()
 
@@ -136,7 +136,7 @@ upon import. First, install the Python 2-only package into your Python 3
 environment::
 
     $ pip3 install mypackagename --no-compile   # to ignore SyntaxErrors
-    
+
 (or use ``pip`` if this points to your Py3 environment.)
 
 Then add the following code at the top of your (Py3 or Py2/3-compatible)

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -63,20 +63,19 @@ Forward-ported types from Python 2
 .. bytes
 .. -----
 .. .. automodule:: future.types.newbytes
-.. 
+..
 .. dict
 .. -----
 .. .. automodule:: future.types.newdict
-.. 
+..
 .. int
 .. ---
 .. .. automodule:: future.builtins.backports.newint
-.. 
+..
 .. range
 .. -----
 .. .. automodule:: future.types.newrange
-.. 
+..
 .. str
 .. ---
 .. .. automodule:: future.types.newstr
-

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -12,7 +12,7 @@ futurize script
 
       - Compatible metaclass syntax on Py3
       - Explicit inheritance from object on Py3
-    
+
    - Bold might make assumptions about which strings on Py2 should be
      unicode strings and which should be bytestrings.
 
@@ -44,4 +44,3 @@ Experimental:
   should import a custom str is a Py3 str-like object which inherits from unicode and
   removes the decode() method and has any other Py3-like behaviours
   (possibly stricter casting?)
-

--- a/docs/standard_library_imports.rst
+++ b/docs/standard_library_imports.rst
@@ -78,7 +78,7 @@ complete list is here::
     import _thread
 
 Note that, as of v0.16.0, ``python-future`` no longer includes an alias for the
-``configparser`` module because a full backport exists (see https://pypi.python.org/pypi/configparser). 
+``configparser`` module because a full backport exists (see https://pypi.python.org/pypi/configparser).
 
 .. _list-standard-library-refactored:
 
@@ -187,11 +187,10 @@ standard library to Python 2.x are also available in ``future.backports``::
     urllib
     xmlrpc.client
     xmlrpc.server
- 
+
 The goal for these modules, unlike the modules in the ``future.moves`` package
 or top-level namespace, is to backport new functionality introduced in Python
 3.3.
 
 If you need the full backport of one of these packages, please open an issue `here
 <https://github.com/PythonCharmers/python-future>`_.
-

--- a/docs/stdlib_incompatibilities.rst
+++ b/docs/stdlib_incompatibilities.rst
@@ -33,14 +33,14 @@ platform string: unicode string on Python 3, byte string on Python 2.
 Python 2::
     >>> array.array(b'b')
     array.array(b'b')
-    
+
     >>> array.array(u'u')
     TypeError: must be char, not unicode
 
 Python 3::
     >>> array.array(b'b')
     TypeError: must be a unicode character, not bytes
-    
+
     >>> array.array(u'b')
     array('b')
 
@@ -54,7 +54,7 @@ You can use the following code on both Python 3 and Python 2::
     import array
 
     # ...
-    
+
     a = array.array(bytes_to_native_str(b'b'))
 
 This was `fixed in Python 2.7.11
@@ -96,7 +96,7 @@ required a native string as its format argument. For example::
 
     >>> from __future__ import unicode_literals
     >>> from struct import pack
-    >>> pack('<4H2I', version, rec_type, build, year, file_hist_flags, ver_can_read) 
+    >>> pack('<4H2I', version, rec_type, build, year, file_hist_flags, ver_can_read)
 
 raised ``TypeError: Struct() argument 1 must be string, not unicode``.
 
@@ -104,4 +104,3 @@ This was `fixed in Python 2.7.7
 <https://hg.python.org/cpython/raw-file/f89216059edf/Misc/NEWS>`_.
 Since then, ``struct.pack()`` now also accepts unicode format
 strings.
-

--- a/docs/str_object.rst
+++ b/docs/str_object.rst
@@ -67,13 +67,13 @@ they are unicode. (See ``posixpath.py``.) Another example is the
 
 
 .. For example, this is permissible on Py2::
-.. 
+..
 ..     >>> u'u' > 10
 ..     True
-.. 
+..
 ..     >>> u'u' <= b'u'
 ..     True
-.. 
+..
 .. On Py3, these raise TypeErrors.
 
 In most other ways, these :class:`builtins.str` objects on Py2 have the
@@ -97,4 +97,3 @@ identically on Python 2.x and 3.x::
 This feature is in alpha. Please leave feedback `here
 <https://github.com/PythonCharmers/python-future/issues>`_ about whether this
 works for you.
-

--- a/docs/translation.rst
+++ b/docs/translation.rst
@@ -19,10 +19,10 @@ Here is how to use it::
 
     $ pip3 install plotrique==0.2.5-7 --no-compile   # to ignore SyntaxErrors
     $ python3
-    
+
 Then pass in a whitelist of module name prefixes to the
 ``past.autotranslate()`` function. Example::
-    
+
     >>> from past import autotranslate
     >>> autotranslate(['plotrique'])
     >>> import plotrique
@@ -40,19 +40,19 @@ This will translate, import and run Python 2 code such as the following::
 
     # Print statements are translated transparently to functions:
     print 'Hello from a print statement'
-     
+
     # xrange() is translated to Py3's range():
     total = 0
     for i in xrange(10):
         total += i
     print 'Total is: %d' % total
-    
+
     # Dictionary methods like .keys() and .items() are supported and
     # return lists as on Python 2:
     d = {'a': 1, 'b': 2}
     assert d.keys() == ['a', 'b']
     assert isinstance(d.items(), list)
-    
+
     # Functions like range, reduce, map, filter also return lists:
     assert isinstance(range(10), list)
 
@@ -72,7 +72,7 @@ This will translate, import and run Python 2 code such as the following::
 
 The attributes of the module are then accessible normally from Python 3.
 For example::
-    
+
     # This Python 3 code works
     >>> type(mypy2module.d)
     builtins.dict
@@ -110,5 +110,3 @@ Known limitations of ``past.translation``
 
 Please report any bugs you find on the ``python-future`` `bug tracker
 <https://github.com/PythonCharmers/python-future/>`_.
-
-

--- a/docs/unicode_literals.rst
+++ b/docs/unicode_literals.rst
@@ -1,4 +1,3 @@
-
 .. _unicode-literals:
 
 Should I import unicode_literals?
@@ -28,7 +27,7 @@ Benefits
 1. String literals are unicode on Python 3. Making them unicode on Python 2
    leads to more consistency of your string types across the two
    runtimes. This can make it easier to understand and debug your code.
-   
+
 2. Code without ``u''`` prefixes is cleaner, one of the claimed advantages
    of Python 3. Even though some unicode strings would require a function
    call to invert them to native strings for some Python 2 APIs (see
@@ -57,7 +56,7 @@ Drawbacks
    of the Linux kernel.)
 
 .. This is a larger-scale change than adding explicit ``u''`` prefixes to
-..  all strings that should be Unicode. 
+..  all strings that should be Unicode.
 
 2. Changing to ``unicode_literals`` will likely introduce regressions on
    Python 2 that require an initial investment of time to find and fix. The
@@ -82,7 +81,7 @@ Drawbacks
    change the return type of the ``unix_style_path`` function from ``str`` to
    ``unicode`` in the user code, which is difficult to anticipate and probably
    unintended.
-   
+
    The counter-argument is that this code is broken, in a portability
    sense; we see this from Python 3 raising a ``TypeError`` upon passing the
    function a byte-string. The code needs to be changed to make explicit
@@ -122,16 +121,16 @@ Drawbacks
 
        >>> def f():
        ...     u"Author: Martin von Löwis"
-       
+
        >>> help(f)
-       
+
        /Users/schofield/Install/anaconda/python.app/Contents/lib/python2.7/pydoc.pyc in pipepager(text, cmd)
           1376     pipe = os.popen(cmd, 'w')
           1377     try:
        -> 1378         pipe.write(text)
           1379         pipe.close()
           1380     except IOError:
-       
+
        UnicodeEncodeError: 'ascii' codec can't encode character u'\xf6' in position 71: ordinal not in range(128)
 
 See `this Stack Overflow thread
@@ -156,18 +155,18 @@ codebase.:
     ``u''`` prefixes for unicode literals on Python 3.3+] is at odds with
     the porting philosophy I've applied to Django, and why I would have
     vetoed taking advantage of it.
-    
+
     "I believe that aiming for a Python 2 codebase with Python 3
     compatibility hacks is a counter-productive way to port a project. You
     end up with all the drawbacks of Python 2 (including the legacy `u`
     prefixes) and none of the advantages Python 3 (especially the sane
     string handling).
-    
+
     "Working to write Python 3 code, with legacy compatibility for Python
     2, is much more rewarding. Of course it takes more effort, but the
     results are much cleaner and much more maintainable. It's really about
     looking towards the future or towards the past.
-    
+
     "I understand the reasons why PEP 414 was proposed and why it was
     accepted. It makes sense for legacy software that is minimally
     maintained. I hope nobody puts Django in this category!"
@@ -182,19 +181,17 @@ Against ``unicode_literals``
     where there are unicode characters in the filesystem path."
 
     -- Armin Ronacher
-    
+
     "+1 from me for avoiding the unicode_literals future, as it can have
     very strange side effects in Python 2.... This is one of the key
     reasons I backed Armin's PEP 414."
 
     -- Nick Coghlan
-    
+
     "Yeah, one of the nuisances of the WSGI spec is that the header values
     IIRC are the str or StringType on both py2 and py3. With
     unicode_literals this causes hard-to-spot bugs, as some WSGI servers
     might be more tolerant than others, but usually using unicode in python
     2 for WSGI headers will cause the response to fail."
-    
+
     -- Antti Haapala
-
-

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -10,4 +10,3 @@ We strive to support compatibility between versions of ``python-future``. Part o
 
 Upgrading to v0.12
 ==================
-

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -46,4 +46,3 @@ Examples::
     # prints ['H', 'E', 'L', 'L', 'O']
 
 On Python 3 these decorators are no-ops.
-

--- a/docs/what_else.rst
+++ b/docs/what_else.rst
@@ -23,4 +23,3 @@ compatible code.
 .. include:: metaclasses.rst
 
 ..
-

--- a/docs/why_python3.rst
+++ b/docs/why_python3.rst
@@ -56,11 +56,11 @@ Standard library:
 ~~~~~~~~~~~~~~~~~
 
 - SSL contexts in http.client
-- 
+-
 
 
 
 Non-arguments for Python 3
 ==========================
 
-- 
+-

--- a/requirements_py26.txt
+++ b/requirements_py26.txt
@@ -1,4 +1,3 @@
 unittest2
 argparse     # for the http.server module
 importlib
-

--- a/src/future/backports/html/__init__.py
+++ b/src/future/backports/html/__init__.py
@@ -25,4 +25,3 @@ def escape(s, quote=True):
     if quote:
         return s.translate(_escape_map_full)
     return s.translate(_escape_map)
-

--- a/src/future/backports/html/entities.py
+++ b/src/future/backports/html/entities.py
@@ -2512,4 +2512,3 @@ for (name, codepoint) in name2codepoint.items():
     entitydefs[name] = chr(codepoint)
 
 del name, codepoint
-

--- a/src/future/backports/html/parser.py
+++ b/src/future/backports/html/parser.py
@@ -534,4 +534,3 @@ class HTMLParser(_markupbase.ParserBase):
 
         return re.sub(r"&(#?[xX]?(?:[0-9a-fA-F]+;|\w{1,32};?))",
                       replaceEntities, s)
-

--- a/src/future/backports/misc.py
+++ b/src/future/backports/misc.py
@@ -779,7 +779,7 @@ class ChainMap(MutableMapping):
 
     # Py2 compatibility:
     __nonzero__ = __bool__
-        
+
     @recursive_repr()
     def __repr__(self):
         return '{0.__class__.__name__}({1})'.format(

--- a/src/future/backports/test/support.py
+++ b/src/future/backports/test/support.py
@@ -666,7 +666,7 @@ TESTFN = "{0}_{1}_tmp".format(TESTFN, os.getpid())
 #     # First try printable and common characters to have a readable filename.
 #     # For each character, the encoding list are just example of encodings able
 #     # to encode the character (the list is not exhaustive).
-# 
+#
 #     # U+00E6 (Latin Small Letter Ae): cp1252, iso-8859-1
 #     '\u00E6',
 #     # U+0130 (Latin Capital Letter I With Dot Above): cp1254, iso8859_3
@@ -685,11 +685,11 @@ TESTFN = "{0}_{1}_tmp".format(TESTFN, os.getpid())
 #     '\u062A',
 #     # U+0E01 (Thai Character Ko Kai): cp874
 #     '\u0E01',
-# 
+#
 #     # Then try more "special" characters. "special" because they may be
 #     # interpreted or displayed differently depending on the exact locale
 #     # encoding and the font.
-# 
+#
 #     # U+00A0 (No-Break Space)
 #     '\u00A0',
 #     # U+20AC (Euro Sign)
@@ -702,7 +702,7 @@ TESTFN = "{0}_{1}_tmp".format(TESTFN, os.getpid())
 #     else:
 #         FS_NONASCII = character
 #         break
-# 
+#
 # # TESTFN_UNICODE is a non-ascii filename
 # TESTFN_UNICODE = TESTFN + "-\xe0\xf2\u0258\u0141\u011f"
 # if sys.platform == 'darwin':
@@ -712,7 +712,7 @@ TESTFN = "{0}_{1}_tmp".format(TESTFN, os.getpid())
 #     import unicodedata
 #     TESTFN_UNICODE = unicodedata.normalize('NFD', TESTFN_UNICODE)
 # TESTFN_ENCODING = sys.getfilesystemencoding()
-# 
+#
 # # TESTFN_UNENCODABLE is a filename (str type) that should *not* be able to be
 # # encoded by the filesystem encoding (in strict mode). It can be None if we
 # # cannot generate such filename.
@@ -745,7 +745,7 @@ TESTFN = "{0}_{1}_tmp".format(TESTFN, os.getpid())
 #         # File system encoding (eg. ISO-8859-* encodings) can encode
 #         # the byte 0xff. Skip some unicode filename tests.
 #         pass
-# 
+#
 # # TESTFN_UNDECODABLE is a filename (bytes type) that should *not* be able to be
 # # decoded from the filesystem encoding (in strict mode). It can be None if we
 # # cannot generate such filename (ex: the latin1 encoding can decode any byte
@@ -775,7 +775,7 @@ TESTFN = "{0}_{1}_tmp".format(TESTFN, os.getpid())
 #     except UnicodeDecodeError:
 #         TESTFN_UNDECODABLE = os.fsencode(TESTFN) + name
 #         break
-# 
+#
 # if FS_NONASCII:
 #     TESTFN_NONASCII = TESTFN + '-' + FS_NONASCII
 # else:
@@ -1667,15 +1667,15 @@ def run_unittest(*classes):
 # We don't have sysconfig on Py2.6:
 # #=======================================================================
 # # Check for the presence of docstrings.
-# 
+#
 # HAVE_DOCSTRINGS = (check_impl_detail(cpython=False) or
 #                    sys.platform == 'win32' or
 #                    sysconfig.get_config_var('WITH_DOC_STRINGS'))
-# 
+#
 # requires_docstrings = unittest.skipUnless(HAVE_DOCSTRINGS,
 #                                           "test requires docstrings")
-# 
-# 
+#
+#
 # #=======================================================================
 # doctest driver.
 

--- a/src/future/backports/urllib/parse.py
+++ b/src/future/backports/urllib/parse.py
@@ -727,14 +727,14 @@ def quote_from_bytes(bs, safe='/'):
         return str('')
     ### For Python-Future:
     bs = bytes(bs)
-    ### 
+    ###
     if isinstance(safe, str):
         # Normalize 'safe' by converting to bytes and removing non-ASCII chars
         safe = str(safe).encode('ascii', 'ignore')
     else:
         ### For Python-Future:
         safe = bytes(safe)
-        ### 
+        ###
         safe = bytes([c for c in safe if c < 128])
     if not bs.rstrip(_ALWAYS_SAFE_BYTES + safe):
         return bs.decode()

--- a/src/future/builtins/__init__.py
+++ b/src/future/builtins/__init__.py
@@ -38,9 +38,9 @@ from future import utils
 if not utils.PY3:
     # We only import names that shadow the builtins on Py2. No other namespace
     # pollution on Py2.
-    
+
     # Only shadow builtins on Py2; no new names
-    __all__ = ['filter', 'map', 'zip', 
+    __all__ = ['filter', 'map', 'zip',
                'ascii', 'chr', 'hex', 'input', 'next', 'oct', 'open', 'pow',
                'round', 'super',
                'bytes', 'dict', 'int', 'list', 'object', 'range', 'str',

--- a/src/future/builtins/iterators.py
+++ b/src/future/builtins/iterators.py
@@ -7,7 +7,7 @@ And then, for example::
 
     for i in range(10**15):
         pass
-    
+
     for (a, b) in zip(range(10**15), range(-10**15, 0)):
         pass
 
@@ -50,4 +50,3 @@ else:
     range = builtins.range
     zip = builtins.zip
     __all__ = []
-

--- a/src/future/builtins/newnext.py
+++ b/src/future/builtins/newnext.py
@@ -43,7 +43,7 @@ _SENTINEL = object()
 def newnext(iterator, default=_SENTINEL):
     """
     next(iterator[, default])
-    
+
     Return the next item from the iterator. If default is given and the iterator
     is exhausted, it is returned instead of raising StopIteration.
     """
@@ -68,4 +68,3 @@ def newnext(iterator, default=_SENTINEL):
 
 
 __all__ = ['newnext']
-

--- a/src/future/builtins/newround.py
+++ b/src/future/builtins/newround.py
@@ -1,7 +1,7 @@
 """
 ``python-future``: pure Python implementation of Python 3 round().
 """
- 
+
 from future.utils import PYPY, PY26, bind_method
 
 # Use the decimal module for simplicity of implementation (and
@@ -12,13 +12,13 @@ from decimal import Decimal, ROUND_HALF_EVEN
 def newround(number, ndigits=None):
     """
     See Python 3 documentation: uses Banker's Rounding.
- 
+
     Delegates to the __round__ method if for some reason this exists.
- 
+
     If not, rounds a number to a given precision in decimal digits (default
     0 digits). This returns an int when called with one argument,
     otherwise the same type as the number. ndigits may be negative.
- 
+
     See the test_round method in future/tests/test_builtins.py for
     examples.
     """
@@ -28,7 +28,7 @@ def newround(number, ndigits=None):
         ndigits = 0
     if hasattr(number, '__round__'):
         return number.__round__(ndigits)
-    
+
     if ndigits < 0:
         raise NotImplementedError('negative ndigits not supported yet')
     exponent = Decimal('10') ** (-ndigits)
@@ -48,7 +48,7 @@ def newround(number, ndigits=None):
         return int(d)
     else:
         return float(d)
- 
+
 
 ### From Python 2.7's decimal.py. Only needed to support Py2.6:
 

--- a/src/future/moves/test/support.py
+++ b/src/future/moves/test/support.py
@@ -8,4 +8,3 @@ else:
     __future_module__ = True
     with suspend_hooks():
         from test.test_support import *
-

--- a/src/future/moves/tkinter/colorchooser.py
+++ b/src/future/moves/tkinter/colorchooser.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The tkColorChooser module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/future/moves/tkinter/commondialog.py
+++ b/src/future/moves/tkinter/commondialog.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The tkCommonDialog module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/future/moves/tkinter/constants.py
+++ b/src/future/moves/tkinter/constants.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The Tkconstants module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/future/moves/tkinter/dialog.py
+++ b/src/future/moves/tkinter/dialog.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The Dialog module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/future/moves/tkinter/dnd.py
+++ b/src/future/moves/tkinter/dnd.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The Tkdnd module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/future/moves/tkinter/filedialog.py
+++ b/src/future/moves/tkinter/filedialog.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The FileDialog module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/future/moves/tkinter/font.py
+++ b/src/future/moves/tkinter/font.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The tkFont module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/future/moves/tkinter/messagebox.py
+++ b/src/future/moves/tkinter/messagebox.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The tkMessageBox module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/future/moves/tkinter/scrolledtext.py
+++ b/src/future/moves/tkinter/scrolledtext.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The ScrolledText module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/future/moves/tkinter/simpledialog.py
+++ b/src/future/moves/tkinter/simpledialog.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The SimpleDialog module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/future/moves/tkinter/tix.py
+++ b/src/future/moves/tkinter/tix.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The Tix module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/future/moves/tkinter/ttk.py
+++ b/src/future/moves/tkinter/ttk.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The ttk module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/future/moves/urllib/__init__.py
+++ b/src/future/moves/urllib/__init__.py
@@ -3,4 +3,3 @@ from future.utils import PY3
 
 if not PY3:
     __future_module__ = True
-

--- a/src/future/moves/urllib/error.py
+++ b/src/future/moves/urllib/error.py
@@ -7,10 +7,10 @@ if PY3:
     from urllib.error import *
 else:
     __future_module__ = True
-    
+
     # We use this method to get at the original Py2 urllib before any renaming magic
     # ContentTooShortError = sys.py2_modules['urllib'].ContentTooShortError
-    
+
     with suspend_hooks():
         from urllib import ContentTooShortError
         from urllib2 import URLError, HTTPError

--- a/src/future/moves/urllib/parse.py
+++ b/src/future/moves/urllib/parse.py
@@ -10,7 +10,7 @@ else:
     from urlparse import (ParseResult, SplitResult, parse_qs, parse_qsl,
                           urldefrag, urljoin, urlparse, urlsplit,
                           urlunparse, urlunsplit)
-    
+
     # we use this method to get at the original py2 urllib before any renaming
     # quote = sys.py2_modules['urllib'].quote
     # quote_plus = sys.py2_modules['urllib'].quote_plus
@@ -18,7 +18,7 @@ else:
     # unquote_plus = sys.py2_modules['urllib'].unquote_plus
     # urlencode = sys.py2_modules['urllib'].urlencode
     # splitquery = sys.py2_modules['urllib'].splitquery
-    
+
     with suspend_hooks():
         from urllib import (quote,
                             quote_plus,

--- a/src/future/moves/urllib/request.py
+++ b/src/future/moves/urllib/request.py
@@ -51,7 +51,7 @@ else:
         #                     URLopener,
         #                     FancyURLopener,
         #                     proxy_bypass)
-    
+
         # from urllib2 import (
         #                  AbstractBasicAuthHandler,
         #                  AbstractDigestAuthHandler,
@@ -80,7 +80,7 @@ else:
         #                  UnknownHandler,
         #                  urlopen,
         #                 )
-    
+
         # from urlparse import (
         #                  urldefrag
         #                  urljoin,

--- a/src/future/moves/urllib/response.py
+++ b/src/future/moves/urllib/response.py
@@ -10,4 +10,3 @@ else:
                             addclosehook,
                             addinfo,
                             addinfourl)
-

--- a/src/future/standard_library/__init__.py
+++ b/src/future/standard_library/__init__.py
@@ -397,7 +397,7 @@ def scrub_future_sys_modules():
     """
     Deprecated.
     """
-    return {}    
+    return {}
 
 class suspend_hooks(object):
     """

--- a/src/future/tests/base.py
+++ b/src/future/tests/base.py
@@ -163,7 +163,7 @@ class CodeHandler(unittest.TestCase):
         """
         Converts the code block using ``futurize`` and returns the
         resulting code.
-        
+
         Passing stages=[1] or stages=[2] passes the flag ``--stage1`` or
         ``stage2`` to ``futurize``. Passing both stages runs ``futurize``
         with both stages by default.
@@ -259,10 +259,10 @@ class CodeHandler(unittest.TestCase):
 
         If ignore_imports is True, ignores the presence of any lines
         beginning:
-        
+
             from __future__ import ...
             from future import ...
-            
+
         for the purpose of the comparison.
         """
         output = self.convert(before, stages=stages, all_imports=all_imports,

--- a/src/future/types/__init__.py
+++ b/src/future/types/__init__.py
@@ -15,7 +15,7 @@ It is used as follows::
 
 to bring in the new semantics for these functions from Python 3. And
 then, for example::
-    
+
     b = bytes(b'ABCD')
     assert list(b) == [65, 66, 67, 68]
     assert repr(b) == "b'ABCD'"
@@ -46,7 +46,7 @@ then, for example::
         pass
 
 and::
-    
+
     class VerboseList(list):
         def append(self, item):
             print('Adding an item')
@@ -112,7 +112,7 @@ def disallow_types(argnums, disallowed_types):
     raises a TypeError when f is called if a unicode object is passed as
     `a` or a bytes object is passed as `b`.
 
-    This also skips over keyword arguments, so 
+    This also skips over keyword arguments, so
 
         @disallow_types([0, 1], [unicode, bytes])
         def g(a, b=None):
@@ -130,7 +130,7 @@ def disallow_types(argnums, disallowed_types):
     ...     def __add__(self, other):
     ...          pass
 
-    >>> newbytes('1234') + u'1234'      #doctest: +IGNORE_EXCEPTION_DETAIL 
+    >>> newbytes('1234') + u'1234'      #doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
       ...
     TypeError: can't concat 'bytes' to (unicode) str
@@ -255,4 +255,3 @@ else:
                 unicode: newstr}
 
     __all__ = ['newbytes', 'newdict', 'newint', 'newlist', 'newrange', 'newstr', 'newtypes']
-

--- a/src/future/types/newdict.py
+++ b/src/future/types/newdict.py
@@ -100,7 +100,7 @@ class newdict(with_metaclass(BaseNewDict, _builtin_dict)):
         else:
             value = args[0]
         return super(newdict, cls).__new__(cls, value)
-        
+
     def __native__(self):
         """
         Hook for the future.utils.native() function

--- a/src/future/types/newobject.py
+++ b/src/future/types/newobject.py
@@ -15,10 +15,10 @@ Example use::
 
     a = A()
     print(str(a))
-    
+
     # On Python 2, these relations hold:
     assert unicode(a) == my_unicode_string
-    assert str(a) == my_unicode_string.encode('utf-8') 
+    assert str(a) == my_unicode_string.encode('utf-8')
 
 
 Another example::
@@ -32,7 +32,7 @@ Another example::
             return next(self._iter).upper()
         def __iter__(self):
             return self
-    
+
     assert list(Upper('hello')) == list('HELLO')
 
 """
@@ -62,7 +62,7 @@ class newobject(object):
         next
         __unicode__
         __nonzero__
-    
+
     Subclasses of this class can merely define the Python 3 methods (__next__,
     __str__, and __bool__).
     """
@@ -70,7 +70,7 @@ class newobject(object):
         if hasattr(self, '__next__'):
             return type(self).__next__(self)
         raise TypeError('newobject is not an iterator')
-    
+
     def __unicode__(self):
         # All subclasses of the builtin object should have __str__ defined.
         # Note that old-style classes do not have __str__ defined.
@@ -123,7 +123,7 @@ class newobject(object):
     #     else:
     #         value = args[0]
     #     return super(newdict, cls).__new__(cls, value)
-        
+
     def __native__(self):
         """
         Hook for the future.utils.native() function

--- a/src/future/types/newopen.py
+++ b/src/future/types/newopen.py
@@ -30,4 +30,3 @@ class newopen(object):
 
     def __exit__(self, etype, value, traceback):
         self.f.close()
-

--- a/src/future/types/newstr.py
+++ b/src/future/types/newstr.py
@@ -37,7 +37,7 @@ Note that ``str()`` (and ``print()``) would then normally call the
 ``__unicode__`` method on objects in Python 2. To define string
 representations of your objects portably across Py3 and Py2, use the
 :func:`python_2_unicode_compatible` decorator in  :mod:`future.utils`.
-    
+
 """
 
 from collections import Iterable
@@ -73,7 +73,7 @@ class newstr(with_metaclass(BaseNewStr, unicode)):
 
           str(object='') -> str
           str(bytes_or_buffer[, encoding[, errors]]) -> str
-          
+
           Create a new string object from the given object. If encoding or
           errors is specified, then the object must expose a data buffer
           that will be decoded using the given encoding and error handler.
@@ -81,7 +81,7 @@ class newstr(with_metaclass(BaseNewStr, unicode)):
           or repr(object).
           encoding defaults to sys.getdefaultencoding().
           errors defaults to 'strict'.
-        
+
         """
         if len(args) == 0:
             return super(newstr, cls).__new__(cls)
@@ -100,7 +100,7 @@ class newstr(with_metaclass(BaseNewStr, unicode)):
         else:
             value = args[0]
         return super(newstr, cls).__new__(cls, value)
-        
+
     def __repr__(self):
         """
         Without the u prefix
@@ -128,7 +128,7 @@ class newstr(with_metaclass(BaseNewStr, unicode)):
         else:
             raise TypeError(errmsg.format(type(key)))
         return issubset(list(newkey), list(self))
-    
+
     @no('newbytes')
     def __add__(self, other):
         return newstr(super(newstr, self).__add__(other))

--- a/src/future/utils/surrogateescape.py
+++ b/src/future/utils/surrogateescape.py
@@ -196,5 +196,3 @@ if __name__ == '__main__':
     # c = encodefilename(b)
     # assert c == fn, '%r != %r' % (c, fn)
     # # print("ok")
-
-

--- a/src/libfuturize/fixer_util.py
+++ b/src/libfuturize/fixer_util.py
@@ -62,7 +62,7 @@ def Minus(prefix=None):
 
 def commatize(leafs):
     """
-    Accepts/turns: (Name, Name, ..., Name, Name) 
+    Accepts/turns: (Name, Name, ..., Name, Name)
     Returns/into: (Name, Comma, Name, Comma, ..., Name, Comma, Name)
     """
     new_leafs = []
@@ -272,7 +272,7 @@ def future_import2(feature, node):
     An alternative to future_import() which might not work ...
     """
     root = find_root(node)
-    
+
     if does_tree_import(u"__future__", feature, node):
         return
 
@@ -304,7 +304,7 @@ def parse_args(arglist, scheme):
     Parse a list of arguments into a dict
     """
     arglist = [i for i in arglist if i.type != token.COMMA]
-    
+
     ret_mapping = dict([(k, None) for k in scheme])
 
     for i, arg in enumerate(arglist):
@@ -338,7 +338,7 @@ def touch_import_top(package, name_to_import, node):
     Based on lib2to3.fixer_util.touch_import()
 
     Calling this multiple times adds the imports in reverse order.
-        
+
     Also adds "standard_library.install_aliases()" after "from future import
     standard_library".  This should probably be factored into another function.
     """
@@ -415,7 +415,7 @@ def touch_import_top(package, name_to_import, node):
             children_hooks = [install_hooks, Newline()]
         else:
             children_hooks = []
-        
+
         # FromImport(package, [Leaf(token.NAME, name_to_import, prefix=u" ")])
 
     children_import = [import_, Newline()]
@@ -517,5 +517,3 @@ def wrap_in_fn_call(fn_name, args, prefix=None):
     else:
         assert NotImplementedError('write me')
     return Call(Name(fn_name), newargs, prefix=prefix)
-
-

--- a/src/libfuturize/fixes/__init__.py
+++ b/src/libfuturize/fixes/__init__.py
@@ -94,4 +94,3 @@ libfuturize_fix_names_stage2 = set([
     # 'libfuturize.fixes.fix_unicode_literals_import',
     'libfuturize.fixes.fix_xrange_with_import',  # custom one because of a bug with Py3.3's lib2to3
 ])
-

--- a/src/libfuturize/fixes/fix_UserDict.py
+++ b/src/libfuturize/fixes/fix_UserDict.py
@@ -16,12 +16,12 @@ MAPPING = {'UserDict':  'collections',
 
 # def alternates(members):
 #     return "(" + "|".join(map(repr, members)) + ")"
-# 
-# 
+#
+#
 # def build_pattern(mapping=MAPPING):
 #     mod_list = ' | '.join(["module_name='%s'" % key for key in mapping])
 #     bare_names = alternates(mapping.keys())
-# 
+#
 #     yield """name_import=import_name< 'import' ((%s) |
 #                multiple_imports=dotted_as_names< any* (%s) any* >) >
 #           """ % (mod_list, mod_list)
@@ -33,7 +33,7 @@ MAPPING = {'UserDict':  'collections',
 #                multiple_imports=dotted_as_names<
 #                  any* dotted_as_name< (%s) 'as' any > any* >) >
 #           """ % (mod_list, mod_list)
-# 
+#
 #     # Find usages of module members in code e.g. thread.foo(bar)
 #     yield "power< bare_with_attr=(%s) trailer<'.' any > any* >" % bare_names
 
@@ -100,4 +100,3 @@ class FixUserdict(FixImports):
             new_name = self.replace.get(bare_name.value)
             if new_name:
                 bare_name.replace(Name(new_name, prefix=bare_name.prefix))
-

--- a/src/libfuturize/fixes/fix_absolute_import.py
+++ b/src/libfuturize/fixes/fix_absolute_import.py
@@ -89,4 +89,3 @@ class FixAbsoluteImport(FixImport):
             if exists(base_path + ext):
                 return True
         return False
-

--- a/src/libfuturize/fixes/fix_add__future__imports_except_unicode_literals.py
+++ b/src/libfuturize/fixes/fix_add__future__imports_except_unicode_literals.py
@@ -24,4 +24,3 @@ class FixAddFutureImportsExceptUnicodeLiterals(fixer_base.BaseFix):
         future_import(u"print_function", node)
         future_import(u"division", node)
         future_import(u"absolute_import", node)
-

--- a/src/libfuturize/fixes/fix_basestring.py
+++ b/src/libfuturize/fixes/fix_basestring.py
@@ -15,4 +15,3 @@ class FixBasestring(fixer_base.BaseFix):
 
     def transform(self, node, results):
         touch_import_top(u'past.builtins', 'basestring', node)
-

--- a/src/libfuturize/fixes/fix_cmp.py
+++ b/src/libfuturize/fixes/fix_cmp.py
@@ -31,4 +31,3 @@ class FixCmp(fixer_base.BaseFix):
     def transform(self, node, results):
         name = results["name"]
         touch_import_top(u'past.builtins', name.value, node)
-

--- a/src/libfuturize/fixes/fix_division.py
+++ b/src/libfuturize/fixes/fix_division.py
@@ -10,4 +10,3 @@ at the top so the code runs identically on Py3 and Py2.6/2.7
 """
 
 from libpasteurize.fixes.fix_division import FixDivision
-

--- a/src/libfuturize/fixes/fix_division_safe.py
+++ b/src/libfuturize/fixes/fix_division_safe.py
@@ -67,7 +67,7 @@ class FixDivisionSafe(fixer_base.BaseFix):
         Since the tree needs to be fixed once and only once if and only if it
         matches, we can start discarding matches after the first.
         """
-        if (node.type == self.syms.term and 
+        if (node.type == self.syms.term and
                     len(node.children) == 3 and
                     match_division(node.children[1])):
             expr1, expr2 = node.children[0], node.children[2]
@@ -90,4 +90,3 @@ class FixDivisionSafe(fixer_base.BaseFix):
             return
         touch_import_top(u'past.utils', u'old_div', node)
         return wrap_in_fn_call("old_div", (expr1, expr2), prefix=node.prefix)
-

--- a/src/libfuturize/fixes/fix_execfile.py
+++ b/src/libfuturize/fixes/fix_execfile.py
@@ -35,4 +35,3 @@ class FixExecfile(fixer_base.BaseFix):
     def transform(self, node, results):
         name = results["name"]
         touch_import_top(u'past.builtins', name.value, node)
-

--- a/src/libfuturize/fixes/fix_future_builtins.py
+++ b/src/libfuturize/fixes/fix_future_builtins.py
@@ -57,4 +57,3 @@ class FixFutureBuiltins(fixer_base.BaseFix):
         name = results["name"]
         touch_import_top(u'builtins', name.value, node)
         # name.replace(Name(u"input", prefix=name.prefix))
-

--- a/src/libfuturize/fixes/fix_future_standard_library.py
+++ b/src/libfuturize/fixes/fix_future_standard_library.py
@@ -22,5 +22,3 @@ class FixFutureStandardLibrary(FixImports):
         # TODO: add a blank line between any __future__ imports and this?
         touch_import_top(u'future', u'standard_library', node)
         return result
-
-

--- a/src/libfuturize/fixes/fix_future_standard_library_urllib.py
+++ b/src/libfuturize/fixes/fix_future_standard_library_urllib.py
@@ -26,5 +26,3 @@ class FixFutureStandardLibraryUrllib(FixUrllib):     # not a subclass of FixImpo
         # TODO: add a blank line between any __future__ imports and this?
         touch_import_top(u'future', u'standard_library', root)
         return result
-
-

--- a/src/libfuturize/fixes/fix_order___future__imports.py
+++ b/src/libfuturize/fixes/fix_order___future__imports.py
@@ -34,4 +34,3 @@ class FixOrderFutureImports(fixer_base.BaseFix):
     def transform(self, node, results):
         # TODO    # write me
         pass
-

--- a/src/libfuturize/fixes/fix_print_with_import.py
+++ b/src/libfuturize/fixes/fix_print_with_import.py
@@ -20,4 +20,3 @@ class FixPrintWithImport(FixPrint):
         future_import(u'print_function', node)
         n_stmt = super(FixPrintWithImport, self).transform(node, results)
         return n_stmt
-

--- a/src/libfuturize/fixes/fix_remove_old__future__imports.py
+++ b/src/libfuturize/fixes/fix_remove_old__future__imports.py
@@ -24,4 +24,3 @@ class FixRemoveOldFutureImports(fixer_base.BaseFix):
         remove_future_import(u"with_statement", node)
         remove_future_import(u"nested_scopes", node)
         remove_future_import(u"generators", node)
-

--- a/src/libfuturize/fixes/fix_unicode_keep_u.py
+++ b/src/libfuturize/fixes/fix_unicode_keep_u.py
@@ -22,4 +22,3 @@ class FixUnicodeKeepU(fixer_base.BaseFix):
             new = node.clone()
             new.value = _mapping[node.value]
             return new
-

--- a/src/libfuturize/fixes/fix_unicode_literals_import.py
+++ b/src/libfuturize/fixes/fix_unicode_literals_import.py
@@ -1,6 +1,6 @@
 """
 Adds this import:
-    
+
     from __future__ import unicode_literals
 
 """
@@ -16,4 +16,3 @@ class FixUnicodeLiteralsImport(fixer_base.BaseFix):
 
     def transform(self, node, results):
         future_import(u"unicode_literals", node)
-

--- a/src/libfuturize/main.py
+++ b/src/libfuturize/main.py
@@ -91,7 +91,7 @@ def main(args=None):
 
     Returns a suggested exit status (0, 1, 2).
     """
-    
+
     # Set up option parser
     parser = optparse.OptionParser(usage="futurize [options] file|dir ...")
     parser.add_option("-V", "--version", action="store_true",

--- a/src/libpasteurize/fixes/__init__.py
+++ b/src/libpasteurize/fixes/__init__.py
@@ -52,4 +52,3 @@ fix_names = set([
                  'libpasteurize.fixes.fix_unpacking',  # yes, this is useful
                  # 'libpasteurize.fixes.fix_with'      # way out of date
                 ])
-

--- a/src/libpasteurize/fixes/feature_base.py
+++ b/src/libpasteurize/fixes/feature_base.py
@@ -40,7 +40,7 @@ class Features(set):
         Called every time we care about the mapping of names to features.
         """
         self.mapping = dict([(f.name, f) for f in iter(self)])
-    
+
     @property
     def PATTERN(self):
         u"""

--- a/src/libpasteurize/fixes/fix_add_all__future__imports.py
+++ b/src/libpasteurize/fixes/fix_add_all__future__imports.py
@@ -22,4 +22,3 @@ class FixAddAllFutureImports(fixer_base.BaseFix):
         future_import(u"print_function", node)
         future_import(u"division", node)
         future_import(u"absolute_import", node)
-

--- a/src/libpasteurize/fixes/fix_add_all_future_builtins.py
+++ b/src/libpasteurize/fixes/fix_add_all_future_builtins.py
@@ -35,4 +35,3 @@ class FixAddAllFutureBuiltins(fixer_base.BaseFix):
         #                      range round str super zip"""
         # for builtin in sorted(builtins.split(), reverse=True):
         #     touch_import_top(u'builtins', builtin, node)
-

--- a/src/libpasteurize/fixes/fix_annotations.py
+++ b/src/libpasteurize/fixes/fix_annotations.py
@@ -19,7 +19,7 @@ class FixAnnotations(fixer_base.BaseFix):
         if not self.warned:
             self.warned = True
             self.warning(node, reason=reason)
-    
+
     PATTERN = u"""
               funcdef< 'def' any parameters< '(' [params=any] ')' > ['->' ret=any] ':' any* >
               """

--- a/src/libpasteurize/fixes/fix_features.py
+++ b/src/libpasteurize/fixes/fix_features.py
@@ -71,7 +71,7 @@ class FixFeatures(fixer_base.BaseFix):
             # if it's there, so we don't care if it fails for normal reasons.
             pass
         return to_ret
-    
+
     def transform(self, node, results):
         for feature_name in results:
             if feature_name in self.features_warned:

--- a/src/libpasteurize/fixes/fix_fullargspec.py
+++ b/src/libpasteurize/fixes/fix_fullargspec.py
@@ -8,7 +8,7 @@ from lib2to3.fixer_util import Name
 warn_msg = u"some of the values returned by getfullargspec are not valid in Python 2 and have no equivalent."
 
 class FixFullargspec(fixer_base.BaseFix):
-    
+
     PATTERN = u"'getfullargspec'"
 
     def transform(self, node, results):

--- a/src/libpasteurize/fixes/fix_future_builtins.py
+++ b/src/libpasteurize/fixes/fix_future_builtins.py
@@ -44,4 +44,3 @@ class FixFutureBuiltins(fixer_base.BaseFix):
         name = results["name"]
         touch_import_top(u'builtins', name.value, node)
         # name.replace(Name(u"input", prefix=name.prefix))
-

--- a/src/libpasteurize/fixes/fix_imports.py
+++ b/src/libpasteurize/fixes/fix_imports.py
@@ -110,4 +110,3 @@ class FixImports(fixer_base.BaseFix):
 
     def transform(self, node, results):
         touch_import_top(u'future', u'standard_library', node)
-

--- a/src/libpasteurize/fixes/fix_imports2.py
+++ b/src/libpasteurize/fixes/fix_imports2.py
@@ -18,11 +18,11 @@ TK_BASE_NAMES = (u'ACTIVE', u'ALL', u'ANCHOR', u'ARC',u'BASELINE', u'BEVEL', u'B
                  u'RADIOBUTTON', u'RAISED', u'READABLE', u'RIDGE', u'RIGHT',
                  u'ROUND', u'S', u'SCROLL', u'SE', u'SEL', u'SEL_FIRST', u'SEL_LAST',
                  u'SEPARATOR', u'SINGLE', u'SOLID', u'SUNKEN', u'SW', u'StringTypes',
-                 u'TOP', u'TRUE', u'TclVersion', u'TkVersion', u'UNDERLINE', 
+                 u'TOP', u'TRUE', u'TclVersion', u'TkVersion', u'UNDERLINE',
                  u'UNITS', u'VERTICAL', u'W', u'WORD', u'WRITABLE', u'X', u'Y', u'YES',
                  u'wantobjects')
 
-PY2MODULES = { 
+PY2MODULES = {
               u'urllib2' : (
                   u'AbstractBasicAuthHandler', u'AbstractDigestAuthHandler',
                   u'AbstractHTTPHandler', u'BaseHandler', u'CacheFTPHandler',
@@ -172,4 +172,3 @@ class FixImports2(fixer_base.BaseFix):
 
     def transform(self, node, results):
         touch_import_top(u'future', u'standard_library', node)
-

--- a/src/libpasteurize/fixes/fix_kwargs.py
+++ b/src/libpasteurize/fixes/fix_kwargs.py
@@ -61,7 +61,7 @@ def remove_params(raw_params, kwargs_default=_kwargs_default_name):
             return False
     else:
         return True
-    
+
 def needs_fixing(raw_params, kwargs_default=_kwargs_default_name):
     u"""
     Returns string with the name of the kwargs dict if the params after the first star need fixing
@@ -145,4 +145,3 @@ class FixKwargs(fixer_base.BaseFix):
                 arglist.append_child(Comma())
             arglist.append_child(DoubleStar(prefix=u" "))
             arglist.append_child(Name(new_kwargs))
-            

--- a/src/libpasteurize/fixes/fix_metaclass.py
+++ b/src/libpasteurize/fixes/fix_metaclass.py
@@ -61,7 +61,7 @@ class FixMetaclass(fixer_base.BaseFix):
         name = meta
         name.prefix = u" "
         stmt_node = Node(syms.atom, [target, equal, name])
-        
+
         suitify(node)
         for item in node.children:
             if item.type == syms.suite:

--- a/src/libpasteurize/fixes/fix_unpacking.py
+++ b/src/libpasteurize/fixes/fix_unpacking.py
@@ -60,7 +60,7 @@ class FixUnpacking(fixer_base.BaseFix):
         setup_line = Assign(Name(self.LISTNAME), Call(Name(u"list"), [source.clone()]))
         power_line = Assign(target, assignment_source(len(pre), len(post), self.LISTNAME, self.ITERNAME))
         return setup_line, power_line
-        
+
     def fix_implicit_context(self, node, results):
         u"""
         Only example of the implicit context is

--- a/src/libpasteurize/main.py
+++ b/src/libpasteurize/main.py
@@ -146,4 +146,3 @@ def main(args=None):
 
     # Return error status (0 if rt.errors is zero)
     return int(bool(rt.errors))
-

--- a/src/past/__init__.py
+++ b/src/past/__init__.py
@@ -67,7 +67,7 @@ this::
 
 until the authors of the Python 2 modules have upgraded their code. Then, for
 example::
-    
+
     >>> mypy2module.func_taking_py2_string(oldstr(b'abcd'))
 
 
@@ -90,4 +90,3 @@ from future import __version__, __copyright__, __license__
 
 __title__ = 'past'
 __author__ = 'Ed Schofield'
-

--- a/src/past/builtins/__init__.py
+++ b/src/past/builtins/__init__.py
@@ -59,9 +59,9 @@ from past import utils
 if utils.PY3:
     # We only import names that shadow the builtins on Py3. No other namespace
     # pollution on Py3.
-    
+
     # Only shadow builtins on Py3; no new names
-    __all__ = ['filter', 'map', 'range', 'reduce', 'zip', 
+    __all__ = ['filter', 'map', 'range', 'reduce', 'zip',
                'basestring', 'dict', 'str', 'long', 'unicode',
                'apply', 'chr', 'cmp', 'execfile', 'intern', 'raw_input',
                'reload', 'unichr', 'xrange'

--- a/src/past/builtins/misc.py
+++ b/src/past/builtins/misc.py
@@ -87,4 +87,3 @@ if PY3:
                'reload', 'unichr', 'unicode', 'xrange']
 else:
     __all__ = []
-

--- a/src/past/builtins/noniterators.py
+++ b/src/past/builtins/noniterators.py
@@ -6,7 +6,7 @@ This module is designed to be used as follows::
 And then, for example::
 
     assert isinstance(range(5), list)
-    
+
 The list-producing functions this brings in are::
 
 - ``filter``
@@ -19,7 +19,7 @@ The list-producing functions this brings in are::
 
 from __future__ import division, absolute_import, print_function
 
-from itertools import chain, starmap    
+from itertools import chain, starmap
 import itertools       # since zip_longest doesn't exist on Py2
 from past.types import basestring
 from past.utils import PY3
@@ -36,7 +36,7 @@ if PY3:
     def oldfilter(*args):
         """
         filter(function or None, sequence) -> list, tuple, or string
-        
+
         Return those items of sequence for which function(item) is true.
         If function is None, return the items that are true.  If sequence
         is a tuple or string, return the same type, else return a list.
@@ -56,7 +56,7 @@ if PY3:
     def oldmap(func, *iterables):
         """
         map(function, sequence[, sequence, ...]) -> list
-        
+
         Return a list of the results of applying the function to the
         items of the argument sequence(s).  If more than one sequence is
         given, the function is called with an argument list consisting of
@@ -64,7 +64,7 @@ if PY3:
         missing values when not all sequences have the same length.  If
         the function is None, return a list of the items of the sequence
         (or a list of tuples if more than one sequence).
-        
+
         Test cases:
         >>> oldmap(None, 'hello world')
         ['h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd']
@@ -102,22 +102,22 @@ if PY3:
         #         PyObject *it;           /* the iterator object */
         #         int saw_StopIteration;  /* bool:  did the iterator end? */
         #     } sequence;
-        # 
+        #
         #     PyObject *func, *result;
         #     sequence *seqs = NULL, *sqp;
         #     Py_ssize_t n, len;
         #     register int i, j;
-        # 
+        #
         #     n = PyTuple_Size(args);
         #     if (n < 2) {
         #         PyErr_SetString(PyExc_TypeError,
         #                         "map() requires at least two args");
         #         return NULL;
         #     }
-        # 
+        #
         #     func = PyTuple_GetItem(args, 0);
         #     n--;
-        # 
+        #
         #     if (func == Py_None) {
         #         if (PyErr_WarnPy3k("map(None, ...) not supported in 3.x; "
         #                            "use list(...)", 1) < 0)
@@ -127,7 +127,7 @@ if PY3:
         #             return PySequence_List(PyTuple_GetItem(args, 1));
         #         }
         #     }
-        # 
+        #
         #     /* Get space for sequence descriptors.  Must NULL out the iterator
         #      * pointers so that jumping to Fail_2 later doesn't see trash.
         #      */
@@ -139,7 +139,7 @@ if PY3:
         #         seqs[i].it = (PyObject*)NULL;
         #         seqs[i].saw_StopIteration = 0;
         #     }
-        # 
+        #
         #     /* Do a first pass to obtain iterators for the arguments, and set len
         #      * to the largest of their lengths.
         #      */
@@ -147,7 +147,7 @@ if PY3:
         #     for (i = 0, sqp = seqs; i < n; ++i, ++sqp) {
         #         PyObject *curseq;
         #         Py_ssize_t curlen;
-        # 
+        #
         #         /* Get iterator. */
         #         curseq = PyTuple_GetItem(args, i+1);
         #         sqp->it = PyObject_GetIter(curseq);
@@ -159,27 +159,27 @@ if PY3:
         #             PyErr_SetString(PyExc_TypeError, errbuf);
         #             goto Fail_2;
         #         }
-        # 
+        #
         #         /* Update len. */
         #         curlen = _PyObject_LengthHint(curseq, 8);
         #         if (curlen > len)
         #             len = curlen;
         #     }
-        # 
+        #
         #     /* Get space for the result list. */
         #     if ((result = (PyObject *) PyList_New(len)) == NULL)
         #         goto Fail_2;
-        # 
+        #
         #     /* Iterate over the sequences until all have stopped. */
         #     for (i = 0; ; ++i) {
         #         PyObject *alist, *item=NULL, *value;
         #         int numactive = 0;
-        # 
+        #
         #         if (func == Py_None && n == 1)
         #             alist = NULL;
         #         else if ((alist = PyTuple_New(n)) == NULL)
         #             goto Fail_1;
-        # 
+        #
         #         for (j = 0, sqp = seqs; j < n; ++j, ++sqp) {
         #             if (sqp->saw_StopIteration) {
         #                 Py_INCREF(Py_None);
@@ -204,15 +204,15 @@ if PY3:
         #             else
         #                 break;
         #         }
-        # 
+        #
         #         if (!alist)
         #             alist = item;
-        # 
+        #
         #         if (numactive == 0) {
         #             Py_DECREF(alist);
         #             break;
         #         }
-        # 
+        #
         #         if (func == Py_None)
         #             value = alist;
         #         else {
@@ -230,12 +230,12 @@ if PY3:
         #         else if (PyList_SetItem(result, i, value) < 0)
         #             goto Fail_1;
         #     }
-        # 
+        #
         #     if (i < len && PyList_SetSlice(result, i, len, NULL) < 0)
         #         goto Fail_1;
-        # 
+        #
         #     goto Succeed;
-        # 
+        #
         # Fail_1:
         #     Py_DECREF(result);
         # Fail_2:
@@ -270,4 +270,3 @@ else:
     reduce = __builtin__.reduce
     zip = __builtin__.zip
     __all__ = []
-

--- a/src/past/translation/__init__.py
+++ b/src/past/translation/__init__.py
@@ -28,7 +28,7 @@ You can unregister the hook using::
     >>> from past.translation import remove_hooks
     >>> remove_hooks()
 
-Author: Ed Schofield. 
+Author: Ed Schofield.
 Inspired by and based on ``uprefix`` by Vinay M. Sajip.
 """
 
@@ -220,16 +220,16 @@ def detect_python2(source, pathname):
         # The above fixers made changes, so we conclude it's Python 2 code
         logger.debug('Detected Python 2 code: {0}'.format(pathname))
         with open('/tmp/original_code.py', 'w') as f:
-            f.write('### Original code (detected as py2): %s\n%s' % 
+            f.write('### Original code (detected as py2): %s\n%s' %
                     (pathname, source))
         with open('/tmp/py2_detection_code.py', 'w') as f:
-            f.write('### Code after running py3 detection (from %s)\n%s' % 
+            f.write('### Code after running py3 detection (from %s)\n%s' %
                     (pathname, str(tree)[:-1]))
         return True
     else:
         logger.debug('Detected Python 3 code: {0}'.format(pathname))
         with open('/tmp/original_code.py', 'w') as f:
-            f.write('### Original code (detected as py3): %s\n%s' % 
+            f.write('### Original code (detected as py3): %s\n%s' %
                     (pathname, source))
         try:
             os.remove('/tmp/futurize_code.py')
@@ -359,7 +359,7 @@ class Py2Fixer(object):
                 # Is the test in the next line more or less robust than the
                 # following one? Presumably less ...
                 # ispkg = self.pathname.endswith('__init__.py')
-                
+
                 if self.kind == imp.PKG_DIRECTORY:
                     mod.__path__ = [ os.path.dirname(self.pathname) ]
                     mod.__package__ = fullname
@@ -367,7 +367,7 @@ class Py2Fixer(object):
                     #else, regular module
                     mod.__path__ = []
                     mod.__package__ = fullname.rpartition('.')[0]
-                    
+
                 try:
                     cachename = imp.cache_from_source(self.pathname)
                     if not os.path.exists(cachename):
@@ -396,7 +396,7 @@ class Py2Fixer(object):
                         if detect_python2(source, self.pathname):
                             source = self.transform(source)
                             with open('/tmp/futurized_code.py', 'w') as f:
-                                f.write('### Futurized code (from %s)\n%s' % 
+                                f.write('### Futurized code (from %s)\n%s' %
                                         (self.pathname, source))
 
                         code = compile(source, self.pathname, 'exec')
@@ -457,7 +457,7 @@ def detect_hooks():
 class hooks(object):
     """
     Acts as a context manager. Use like this:
-    
+
     >>> from past import translation
     >>> with translation.hooks():
     ...     import mypy2module
@@ -477,7 +477,7 @@ class hooks(object):
 class suspend_hooks(object):
     """
     Acts as a context manager. Use like this:
-    
+
     >>> from past import translation
     >>> translation.install_hooks()
     >>> import http.client
@@ -495,4 +495,3 @@ class suspend_hooks(object):
     def __exit__(self, *args):
         if self.hooks_were_installed:
             install_hooks()
-

--- a/src/past/types/__init__.py
+++ b/src/past/types/__init__.py
@@ -27,4 +27,3 @@ else:
     unicode = str
     # from .unicode import unicode
     __all__ = ['basestring', 'olddict', 'oldstr', 'long', 'unicode']
-

--- a/src/past/types/basestring.py
+++ b/src/past/types/basestring.py
@@ -37,4 +37,3 @@ class basestring(with_metaclass(BaseBaseString)):
 
 
 __all__ = ['basestring']
-

--- a/src/past/types/olddict.py
+++ b/src/past/types/olddict.py
@@ -71,7 +71,7 @@ class olddict(with_metaclass(BaseOldDict, _builtin_dict)):
     #         in the keyword argument list.  For example:  dict(one=1, two=2)
 
     #     """
-    #     
+    #
     #     if len(args) == 0:
     #         return super(olddict, cls).__new__(cls)
     #     # Was: elif isinstance(args[0], newbytes):
@@ -85,7 +85,7 @@ class olddict(with_metaclass(BaseOldDict, _builtin_dict)):
     #     else:
     #         value = args[0]
     #     return super(olddict, cls).__new__(cls, value)
-        
+
     def __native__(self):
         """
         Hook for the past.utils.native() function
@@ -94,4 +94,3 @@ class olddict(with_metaclass(BaseOldDict, _builtin_dict)):
 
 
 __all__ = ['olddict']
-

--- a/src/past/types/oldstr.py
+++ b/src/past/types/oldstr.py
@@ -32,7 +32,7 @@ def unescape(s):
     def
     """
     return s.encode().decode('unicode_escape')
-    
+
 
 class oldstr(with_metaclass(BaseOldStr, _builtin_bytes)):
     """
@@ -55,14 +55,14 @@ class oldstr(with_metaclass(BaseOldStr, _builtin_bytes)):
     #     bytes(bytes_or_buffer) -> immutable copy of bytes_or_buffer
     #     bytes(int) -> bytes object of size given by the parameter initialized with null bytes
     #     bytes() -> empty bytes object
-    #     
+    #
     #     Construct an immutable array of bytes from:
     #       - an iterable yielding integers in range(256)
     #       - a text string encoded using the specified encoding
     #       - any object implementing the buffer API.
     #       - an integer
     #     """
-    #     
+    #
     #     if len(args) == 0:
     #         return super(newbytes, cls).__new__(cls)
     #     # Was: elif isinstance(args[0], newbytes):
@@ -84,7 +84,7 @@ class oldstr(with_metaclass(BaseOldStr, _builtin_bytes)):
     #         if 'errors' in kwargs:
     #             newargs.append(kwargs['errors'])
     #         value = args[0].encode(*newargs)
-    #         ### 
+    #         ###
     #     elif isinstance(args[0], Iterable):
     #         if len(args[0]) == 0:
     #             # What is this?
@@ -101,7 +101,7 @@ class oldstr(with_metaclass(BaseOldStr, _builtin_bytes)):
     #     else:
     #         value = args[0]
     #     return super(newbytes, cls).__new__(cls, value)
-        
+
     def __repr__(self):
         s = super(oldstr, self).__repr__()   # e.g. b'abc' on Py3, b'abc' on Py3
         return s[1:]
@@ -124,7 +124,7 @@ class oldstr(with_metaclass(BaseOldStr, _builtin_bytes)):
     def __contains__(self, key):
         if isinstance(key, int):
             return False
-    
+
     def __native__(self):
         return bytes(self)
 

--- a/src/past/utils/__init__.py
+++ b/src/past/utils/__init__.py
@@ -26,13 +26,13 @@ def with_metaclass(meta, *bases):
     Function from jinja2/_compat.py. License: BSD.
 
     Use it like this::
-        
+
         class BaseForm(object):
             pass
-        
+
         class FormType(type):
             pass
-        
+
         class Form(with_metaclass(FormType, BaseForm)):
             pass
 
@@ -42,7 +42,7 @@ def with_metaclass(meta, *bases):
     we also need to make sure that we downgrade the custom metaclass
     for one level to something closer to type (that's why __call__ and
     __init__ comes back from type etc.).
-    
+
     This has the advantage over six.with_metaclass of not introducing
     dummy classes into the final MRO.
     """
@@ -62,7 +62,7 @@ def native(obj):
 
     On Py3, returns the corresponding native Py3 types that are
     superclasses for forward-ported objects from Py2:
-    
+
     >>> from past.builtins import str, dict
 
     >>> native(str(b'ABC'))   # Output on Py3 follows. On Py2, output is 'ABC'

--- a/src/tkinter/colorchooser.py
+++ b/src/tkinter/colorchooser.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The tkColorChooser module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/tkinter/commondialog.py
+++ b/src/tkinter/commondialog.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The tkCommonDialog module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/tkinter/constants.py
+++ b/src/tkinter/constants.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The Tkconstants module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/tkinter/dialog.py
+++ b/src/tkinter/dialog.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The Dialog module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/tkinter/dnd.py
+++ b/src/tkinter/dnd.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The Tkdnd module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/tkinter/font.py
+++ b/src/tkinter/font.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The tkFont module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/tkinter/messagebox.py
+++ b/src/tkinter/messagebox.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The tkMessageBox module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/tkinter/scrolledtext.py
+++ b/src/tkinter/scrolledtext.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The ScrolledText module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/tkinter/simpledialog.py
+++ b/src/tkinter/simpledialog.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The SimpleDialog module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/tkinter/tix.py
+++ b/src/tkinter/tix.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The Tix module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/src/tkinter/ttk.py
+++ b/src/tkinter/ttk.py
@@ -10,4 +10,3 @@ else:
     except ImportError:
         raise ImportError('The ttk module is missing. Does your Py2 '
                           'installation include tkinter?')
-

--- a/tests/test_future/test_decorators.py
+++ b/tests/test_future/test_decorators.py
@@ -36,14 +36,14 @@ class TestDecorators(unittest.TestCase):
             assert str(a) == str(b)
 
     def test_implements_iterator(self):
-        
+
         @implements_iterator
         class MyIter(object):
             def __next__(self):
                 return 'Next!'
             def __iter__(self):
                 return self
-        
+
         itr = MyIter()
         self.assertEqual(next(itr), 'Next!')
 

--- a/tests/test_future/test_futurize.py
+++ b/tests/test_future/test_futurize.py
@@ -452,7 +452,7 @@ class TestFuturizeSimple(CodeHandler):
             pass
         """
         self.convert_check(before, after, ignore_imports=False)
-    
+
     def test_source_coding_utf8(self):
         """
         Tests to ensure that the source coding line is not corrupted or
@@ -517,13 +517,13 @@ class TestFuturizeSimple(CodeHandler):
         before = '''
         def addup(*x):
             return sum(x)
-        
+
         assert apply(addup, (10,20)) == 30
         '''
         after = """
         def addup(*x):
             return sum(x)
-        
+
         assert addup(*(10,20)) == 30
         """
         self.convert_check(before, after)
@@ -662,7 +662,7 @@ class TestFuturizeRenamedStdlib(CodeHandler):
         from future import standard_library
         standard_library.install_aliases()
         import urllib.request
-        
+
         URL = 'http://pypi.python.org/pypi/future/json'
         package = 'future'
         r = urllib.request.urlopen(URL.format(package))
@@ -1045,13 +1045,13 @@ class TestFuturizeStage1(CodeHandler):
         #
         # another comment
         #
-        
+
         CONSTANTS = [ 0, 01, 011, 0111, 012, 02, 021, 0211, 02111, 013 ]
         _RN_LETTERS = "IVXLCDM"
-        
+
         def my_func(value):
             pass
-        
+
         ''' Docstring-like comment here '''
         """
         self.convert(code)

--- a/tests/test_future/test_libfuturize_fixers.py
+++ b/tests/test_future/test_libfuturize_fixers.py
@@ -25,7 +25,7 @@ proj_dir = os.path.normpath(os.path.join(test_dir, ".."))
 # grammar_path = os.path.join(test_dir, "..", "Grammar.txt")
 # grammar = driver.load_grammar(grammar_path)
 # driver = driver.Driver(grammar, convert=pytree.convert)
-# 
+#
 # def parse_string(string):
 #     return driver.parse_string(reformat(string), debug=True)
 
@@ -118,118 +118,118 @@ class FixerTestCase(unittest.TestCase):
 
 
 ############### EDIT the tests below ...
-# 
+#
 # class Test_ne(FixerTestCase):
 #     fixer = "ne"
-# 
+#
 #     def test_basic(self):
 #         b = """if x <> y:
 #             pass"""
-# 
+#
 #         a = """if x != y:
 #             pass"""
 #         self.check(b, a)
-# 
-# 
+#
+#
 # class Test_print(FixerTestCase):
 #     fixer = "print_"
-# 
+#
 #     def test_print(self):
 #         b = """print 'Hello world'"""
 #         a = """from __future__ import print_function\nprint('Hello world')"""
 #         self.check(b, a)
-# 
-# 
+#
+#
 # class Test_apply(FixerTestCase):
 #     fixer = "apply"
-# 
+#
 #     def test_1(self):
 #         b = """x = apply(f, g + h)"""
 #         a = """x = f(*g + h)"""
 #         self.check(b, a)
-# 
-# 
+#
+#
 # class Test_intern(FixerTestCase):
 #     fixer = "intern"
-# 
+#
 #     def test_prefix_preservation(self):
 #         b = """x =   intern(  a  )"""
 #         a = """import sys\nx =   sys.intern(  a  )"""
 #         self.check(b, a)
-# 
+#
 #         b = """y = intern("b" # test
 #               )"""
 #         a = """import sys\ny = sys.intern("b" # test
 #               )"""
 #         self.check(b, a)
-# 
+#
 #         b = """z = intern(a+b+c.d,   )"""
 #         a = """import sys\nz = sys.intern(a+b+c.d,   )"""
 #         self.check(b, a)
-# 
+#
 #     def test(self):
 #         b = """x = intern(a)"""
 #         a = """import sys\nx = sys.intern(a)"""
 #         self.check(b, a)
-# 
+#
 #         b = """z = intern(a+b+c.d,)"""
 #         a = """import sys\nz = sys.intern(a+b+c.d,)"""
 #         self.check(b, a)
-# 
+#
 #         b = """intern("y%s" % 5).replace("y", "")"""
 #         a = """import sys\nsys.intern("y%s" % 5).replace("y", "")"""
 #         self.check(b, a)
-# 
+#
 #     # These should not be refactored
-# 
+#
 #     def test_unchanged(self):
 #         s = """intern(a=1)"""
 #         self.unchanged(s)
-# 
+#
 #         s = """intern(f, g)"""
 #         self.unchanged(s)
-# 
+#
 #         s = """intern(*h)"""
 #         self.unchanged(s)
-# 
+#
 #         s = """intern(**i)"""
 #         self.unchanged(s)
-# 
+#
 #         s = """intern()"""
 #         self.unchanged(s)
-# 
+#
 # class Test_reduce(FixerTestCase):
 #     fixer = "reduce"
-# 
+#
 #     def test_simple_call(self):
 #         b = "reduce(a, b, c)"
 #         a = "from functools import reduce\nreduce(a, b, c)"
 #         self.check(b, a)
-# 
+#
 #     def test_bug_7253(self):
 #         # fix_tuple_params was being bad and orphaning nodes in the tree.
 #         b = "def x(arg): reduce(sum, [])"
 #         a = "from functools import reduce\ndef x(arg): reduce(sum, [])"
 #         self.check(b, a)
-# 
+#
 #     def test_call_with_lambda(self):
 #         b = "reduce(lambda x, y: x + y, seq)"
 #         a = "from functools import reduce\nreduce(lambda x, y: x + y, seq)"
 #         self.check(b, a)
-# 
+#
 #     def test_unchanged(self):
 #         s = "reduce(a)"
 #         self.unchanged(s)
-# 
+#
 #         s = "reduce(a, b=42)"
 #         self.unchanged(s)
-# 
+#
 #         s = "reduce(a, b, c, d)"
 #         self.unchanged(s)
-# 
+#
 #         s = "reduce(**c)"
 #         self.unchanged(s)
-# 
+#
 #         s = "reduce()"
 #         self.unchanged(s)
 
@@ -341,96 +341,96 @@ class Test_print(FixerTestCase):
 
 # class Test_exec(FixerTestCase):
 #     fixer = "exec"
-# 
+#
 #     def test_prefix_preservation(self):
 #         b = """  exec code in ns1,   ns2"""
 #         a = """  exec(code, ns1,   ns2)"""
 #         self.check(b, a)
-# 
+#
 #     def test_basic(self):
 #         b = """exec code"""
 #         a = """exec(code)"""
 #         self.check(b, a)
-# 
+#
 #     def test_with_globals(self):
 #         b = """exec code in ns"""
 #         a = """exec(code, ns)"""
 #         self.check(b, a)
-# 
+#
 #     def test_with_globals_locals(self):
 #         b = """exec code in ns1, ns2"""
 #         a = """exec(code, ns1, ns2)"""
 #         self.check(b, a)
-# 
+#
 #     def test_complex_1(self):
 #         b = """exec (a.b()) in ns"""
 #         a = """exec((a.b()), ns)"""
 #         self.check(b, a)
-# 
+#
 #     def test_complex_2(self):
 #         b = """exec a.b() + c in ns"""
 #         a = """exec(a.b() + c, ns)"""
 #         self.check(b, a)
-# 
+#
 #     # These should not be touched
-# 
+#
 #     def test_unchanged_1(self):
 #         s = """exec(code)"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_2(self):
 #         s = """exec (code)"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_3(self):
 #         s = """exec(code, ns)"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_4(self):
 #         s = """exec(code, ns1, ns2)"""
 #         self.unchanged(s)
-# 
+#
 # class Test_repr(FixerTestCase):
 #     fixer = "repr"
-# 
+#
 #     def test_prefix_preservation(self):
 #         b = """x =   `1 + 2`"""
 #         a = """x =   repr(1 + 2)"""
 #         self.check(b, a)
-# 
+#
 #     def test_simple_1(self):
 #         b = """x = `1 + 2`"""
 #         a = """x = repr(1 + 2)"""
 #         self.check(b, a)
-# 
+#
 #     def test_simple_2(self):
 #         b = """y = `x`"""
 #         a = """y = repr(x)"""
 #         self.check(b, a)
-# 
+#
 #     def test_complex(self):
 #         b = """z = `y`.__repr__()"""
 #         a = """z = repr(y).__repr__()"""
 #         self.check(b, a)
-# 
+#
 #     def test_tuple(self):
 #         b = """x = `1, 2, 3`"""
 #         a = """x = repr((1, 2, 3))"""
 #         self.check(b, a)
-# 
+#
 #     def test_nested(self):
 #         b = """x = `1 + `2``"""
 #         a = """x = repr(1 + repr(2))"""
 #         self.check(b, a)
-# 
+#
 #     def test_nested_tuples(self):
 #         b = """x = `1, 2 + `3, 4``"""
 #         a = """x = repr((1, 2 + repr((3, 4))))"""
 #         self.check(b, a)
-# 
+#
 # class Test_except(FixerTestCase):
 #     fixer = "except"
-# 
+#
 #     def test_prefix_preservation(self):
 #         b = """
 #             try:
@@ -443,7 +443,7 @@ class Test_print(FixerTestCase):
 #             except (RuntimeError, ImportError) as    e:
 #                 pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_simple(self):
 #         b = """
 #             try:
@@ -456,7 +456,7 @@ class Test_print(FixerTestCase):
 #             except Foo as e:
 #                 pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_simple_no_space_before_target(self):
 #         b = """
 #             try:
@@ -469,7 +469,7 @@ class Test_print(FixerTestCase):
 #             except Foo as e:
 #                 pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_tuple_unpack(self):
 #         b = """
 #             def foo():
@@ -479,7 +479,7 @@ class Test_print(FixerTestCase):
 #                     pass
 #                 except ImportError, e:
 #                     pass"""
-# 
+#
 #         a = """
 #             def foo():
 #                 try:
@@ -490,28 +490,28 @@ class Test_print(FixerTestCase):
 #                 except ImportError as e:
 #                     pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_multi_class(self):
 #         b = """
 #             try:
 #                 pass
 #             except (RuntimeError, ImportError), e:
 #                 pass"""
-# 
+#
 #         a = """
 #             try:
 #                 pass
 #             except (RuntimeError, ImportError) as e:
 #                 pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_list_unpack(self):
 #         b = """
 #             try:
 #                 pass
 #             except Exception, [a, b]:
 #                 pass"""
-# 
+#
 #         a = """
 #             try:
 #                 pass
@@ -519,14 +519,14 @@ class Test_print(FixerTestCase):
 #                 [a, b] = xxx_todo_changeme.args
 #                 pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_weird_target_1(self):
 #         b = """
 #             try:
 #                 pass
 #             except Exception, d[5]:
 #                 pass"""
-# 
+#
 #         a = """
 #             try:
 #                 pass
@@ -534,14 +534,14 @@ class Test_print(FixerTestCase):
 #                 d[5] = xxx_todo_changeme
 #                 pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_weird_target_2(self):
 #         b = """
 #             try:
 #                 pass
 #             except Exception, a.foo:
 #                 pass"""
-# 
+#
 #         a = """
 #             try:
 #                 pass
@@ -549,14 +549,14 @@ class Test_print(FixerTestCase):
 #                 a.foo = xxx_todo_changeme
 #                 pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_weird_target_3(self):
 #         b = """
 #             try:
 #                 pass
 #             except Exception, a().foo:
 #                 pass"""
-# 
+#
 #         a = """
 #             try:
 #                 pass
@@ -564,7 +564,7 @@ class Test_print(FixerTestCase):
 #                 a().foo = xxx_todo_changeme
 #                 pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_bare_except(self):
 #         b = """
 #             try:
@@ -573,7 +573,7 @@ class Test_print(FixerTestCase):
 #                 pass
 #             except:
 #                 pass"""
-# 
+#
 #         a = """
 #             try:
 #                 pass
@@ -582,7 +582,7 @@ class Test_print(FixerTestCase):
 #             except:
 #                 pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_bare_except_and_else_finally(self):
 #         b = """
 #             try:
@@ -595,7 +595,7 @@ class Test_print(FixerTestCase):
 #                 pass
 #             finally:
 #                 pass"""
-# 
+#
 #         a = """
 #             try:
 #                 pass
@@ -608,7 +608,7 @@ class Test_print(FixerTestCase):
 #             finally:
 #                 pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_multi_fixed_excepts_before_bare_except(self):
 #         b = """
 #             try:
@@ -619,7 +619,7 @@ class Test_print(FixerTestCase):
 #                 pass
 #             except:
 #                 pass"""
-# 
+#
 #         a = """
 #             try:
 #                 pass
@@ -630,7 +630,7 @@ class Test_print(FixerTestCase):
 #             except:
 #                 pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_one_line_suites(self):
 #         b = """
 #             try: raise TypeError
@@ -676,9 +676,9 @@ class Test_print(FixerTestCase):
 #             finally: done()
 #             """
 #         self.check(b, a)
-# 
+#
 #     # These should not be touched:
-# 
+#
 #     def test_unchanged_1(self):
 #         s = """
 #             try:
@@ -686,7 +686,7 @@ class Test_print(FixerTestCase):
 #             except:
 #                 pass"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_2(self):
 #         s = """
 #             try:
@@ -694,7 +694,7 @@ class Test_print(FixerTestCase):
 #             except Exception:
 #                 pass"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_3(self):
 #         s = """
 #             try:
@@ -702,87 +702,87 @@ class Test_print(FixerTestCase):
 #             except (Exception, SystemExit):
 #                 pass"""
 #         self.unchanged(s)
-# 
+#
 # class Test_raise(FixerTestCase):
 #     fixer = "raise"
-# 
+#
 #     def test_basic(self):
 #         b = """raise Exception, 5"""
 #         a = """raise Exception(5)"""
 #         self.check(b, a)
-# 
+#
 #     def test_prefix_preservation(self):
 #         b = """raise Exception,5"""
 #         a = """raise Exception(5)"""
 #         self.check(b, a)
-# 
+#
 #         b = """raise   Exception,    5"""
 #         a = """raise   Exception(5)"""
 #         self.check(b, a)
-# 
+#
 #     def test_with_comments(self):
 #         b = """raise Exception, 5 # foo"""
 #         a = """raise Exception(5) # foo"""
 #         self.check(b, a)
-# 
+#
 #         b = """raise E, (5, 6) % (a, b) # foo"""
 #         a = """raise E((5, 6) % (a, b)) # foo"""
 #         self.check(b, a)
-# 
+#
 #         b = """def foo():
 #                     raise Exception, 5, 6 # foo"""
 #         a = """def foo():
 #                     raise Exception(5).with_traceback(6) # foo"""
 #         self.check(b, a)
-# 
+#
 #     def test_None_value(self):
 #         b = """raise Exception(5), None, tb"""
 #         a = """raise Exception(5).with_traceback(tb)"""
 #         self.check(b, a)
-# 
+#
 #     def test_tuple_value(self):
 #         b = """raise Exception, (5, 6, 7)"""
 #         a = """raise Exception(5, 6, 7)"""
 #         self.check(b, a)
-# 
+#
 #     def test_tuple_detection(self):
 #         b = """raise E, (5, 6) % (a, b)"""
 #         a = """raise E((5, 6) % (a, b))"""
 #         self.check(b, a)
-# 
+#
 #     def test_tuple_exc_1(self):
 #         b = """raise (((E1, E2), E3), E4), V"""
 #         a = """raise E1(V)"""
 #         self.check(b, a)
-# 
+#
 #     def test_tuple_exc_2(self):
 #         b = """raise (E1, (E2, E3), E4), V"""
 #         a = """raise E1(V)"""
 #         self.check(b, a)
-# 
+#
 #     # These should produce a warning
-# 
+#
 #     def test_string_exc(self):
 #         s = """raise 'foo'"""
 #         self.warns_unchanged(s, "Python 3 does not support string exceptions")
-# 
+#
 #     def test_string_exc_val(self):
 #         s = """raise "foo", 5"""
 #         self.warns_unchanged(s, "Python 3 does not support string exceptions")
-# 
+#
 #     def test_string_exc_val_tb(self):
 #         s = """raise "foo", 5, 6"""
 #         self.warns_unchanged(s, "Python 3 does not support string exceptions")
-# 
+#
 #     # These should result in traceback-assignment
-# 
+#
 #     def test_tb_1(self):
 #         b = """def foo():
 #                     raise Exception, 5, 6"""
 #         a = """def foo():
 #                     raise Exception(5).with_traceback(6)"""
 #         self.check(b, a)
-# 
+#
 #     def test_tb_2(self):
 #         b = """def foo():
 #                     a = 5
@@ -793,14 +793,14 @@ class Test_print(FixerTestCase):
 #                     raise Exception(5).with_traceback(6)
 #                     b = 6"""
 #         self.check(b, a)
-# 
+#
 #     def test_tb_3(self):
 #         b = """def foo():
 #                     raise Exception,5,6"""
 #         a = """def foo():
 #                     raise Exception(5).with_traceback(6)"""
 #         self.check(b, a)
-# 
+#
 #     def test_tb_4(self):
 #         b = """def foo():
 #                     a = 5
@@ -811,14 +811,14 @@ class Test_print(FixerTestCase):
 #                     raise Exception(5).with_traceback(6)
 #                     b = 6"""
 #         self.check(b, a)
-# 
+#
 #     def test_tb_5(self):
 #         b = """def foo():
 #                     raise Exception, (5, 6, 7), 6"""
 #         a = """def foo():
 #                     raise Exception(5, 6, 7).with_traceback(6)"""
 #         self.check(b, a)
-# 
+#
 #     def test_tb_6(self):
 #         b = """def foo():
 #                     a = 5
@@ -829,67 +829,67 @@ class Test_print(FixerTestCase):
 #                     raise Exception(5, 6, 7).with_traceback(6)
 #                     b = 6"""
 #         self.check(b, a)
-# 
+#
 # class Test_throw(FixerTestCase):
 #     fixer = "throw"
-# 
+#
 #     def test_1(self):
 #         b = """g.throw(Exception, 5)"""
 #         a = """g.throw(Exception(5))"""
 #         self.check(b, a)
-# 
+#
 #     def test_2(self):
 #         b = """g.throw(Exception,5)"""
 #         a = """g.throw(Exception(5))"""
 #         self.check(b, a)
-# 
+#
 #     def test_3(self):
 #         b = """g.throw(Exception, (5, 6, 7))"""
 #         a = """g.throw(Exception(5, 6, 7))"""
 #         self.check(b, a)
-# 
+#
 #     def test_4(self):
 #         b = """5 + g.throw(Exception, 5)"""
 #         a = """5 + g.throw(Exception(5))"""
 #         self.check(b, a)
-# 
+#
 #     # These should produce warnings
-# 
+#
 #     def test_warn_1(self):
 #         s = """g.throw("foo")"""
 #         self.warns_unchanged(s, "Python 3 does not support string exceptions")
-# 
+#
 #     def test_warn_2(self):
 #         s = """g.throw("foo", 5)"""
 #         self.warns_unchanged(s, "Python 3 does not support string exceptions")
-# 
+#
 #     def test_warn_3(self):
 #         s = """g.throw("foo", 5, 6)"""
 #         self.warns_unchanged(s, "Python 3 does not support string exceptions")
-# 
+#
 #     # These should not be touched
-# 
+#
 #     def test_untouched_1(self):
 #         s = """g.throw(Exception)"""
 #         self.unchanged(s)
-# 
+#
 #     def test_untouched_2(self):
 #         s = """g.throw(Exception(5, 6))"""
 #         self.unchanged(s)
-# 
+#
 #     def test_untouched_3(self):
 #         s = """5 + g.throw(Exception(5, 6))"""
 #         self.unchanged(s)
-# 
+#
 #     # These should result in traceback-assignment
-# 
+#
 #     def test_tb_1(self):
 #         b = """def foo():
 #                     g.throw(Exception, 5, 6)"""
 #         a = """def foo():
 #                     g.throw(Exception(5).with_traceback(6))"""
 #         self.check(b, a)
-# 
+#
 #     def test_tb_2(self):
 #         b = """def foo():
 #                     a = 5
@@ -900,14 +900,14 @@ class Test_print(FixerTestCase):
 #                     g.throw(Exception(5).with_traceback(6))
 #                     b = 6"""
 #         self.check(b, a)
-# 
+#
 #     def test_tb_3(self):
 #         b = """def foo():
 #                     g.throw(Exception,5,6)"""
 #         a = """def foo():
 #                     g.throw(Exception(5).with_traceback(6))"""
 #         self.check(b, a)
-# 
+#
 #     def test_tb_4(self):
 #         b = """def foo():
 #                     a = 5
@@ -918,14 +918,14 @@ class Test_print(FixerTestCase):
 #                     g.throw(Exception(5).with_traceback(6))
 #                     b = 6"""
 #         self.check(b, a)
-# 
+#
 #     def test_tb_5(self):
 #         b = """def foo():
 #                     g.throw(Exception, (5, 6, 7), 6)"""
 #         a = """def foo():
 #                     g.throw(Exception(5, 6, 7).with_traceback(6))"""
 #         self.check(b, a)
-# 
+#
 #     def test_tb_6(self):
 #         b = """def foo():
 #                     a = 5
@@ -936,14 +936,14 @@ class Test_print(FixerTestCase):
 #                     g.throw(Exception(5, 6, 7).with_traceback(6))
 #                     b = 6"""
 #         self.check(b, a)
-# 
+#
 #     def test_tb_7(self):
 #         b = """def foo():
 #                     a + g.throw(Exception, 5, 6)"""
 #         a = """def foo():
 #                     a + g.throw(Exception(5).with_traceback(6))"""
 #         self.check(b, a)
-# 
+#
 #     def test_tb_8(self):
 #         b = """def foo():
 #                     a = 5
@@ -954,596 +954,596 @@ class Test_print(FixerTestCase):
 #                     a + g.throw(Exception(5).with_traceback(6))
 #                     b = 6"""
 #         self.check(b, a)
-# 
+#
 # class Test_long(FixerTestCase):
 #     fixer = "long"
-# 
+#
 #     def test_1(self):
 #         b = """x = long(x)"""
 #         a = """x = int(x)"""
 #         self.check(b, a)
-# 
+#
 #     def test_2(self):
 #         b = """y = isinstance(x, long)"""
 #         a = """y = isinstance(x, int)"""
 #         self.check(b, a)
-# 
+#
 #     def test_3(self):
 #         b = """z = type(x) in (int, long)"""
 #         a = """z = type(x) in (int, int)"""
 #         self.check(b, a)
-# 
+#
 #     def test_unchanged(self):
 #         s = """long = True"""
 #         self.unchanged(s)
-# 
+#
 #         s = """s.long = True"""
 #         self.unchanged(s)
-# 
+#
 #         s = """def long(): pass"""
 #         self.unchanged(s)
-# 
+#
 #         s = """class long(): pass"""
 #         self.unchanged(s)
-# 
+#
 #         s = """def f(long): pass"""
 #         self.unchanged(s)
-# 
+#
 #         s = """def f(g, long): pass"""
 #         self.unchanged(s)
-# 
+#
 #         s = """def f(x, long=True): pass"""
 #         self.unchanged(s)
-# 
+#
 #     def test_prefix_preservation(self):
 #         b = """x =   long(  x  )"""
 #         a = """x =   int(  x  )"""
 #         self.check(b, a)
-# 
-# 
+#
+#
 # class Test_execfile(FixerTestCase):
 #     fixer = "execfile"
-# 
+#
 #     def test_conversion(self):
 #         b = """execfile("fn")"""
 #         a = """exec(compile(open("fn").read(), "fn", 'exec'))"""
 #         self.check(b, a)
-# 
+#
 #         b = """execfile("fn", glob)"""
 #         a = """exec(compile(open("fn").read(), "fn", 'exec'), glob)"""
 #         self.check(b, a)
-# 
+#
 #         b = """execfile("fn", glob, loc)"""
 #         a = """exec(compile(open("fn").read(), "fn", 'exec'), glob, loc)"""
 #         self.check(b, a)
-# 
+#
 #         b = """execfile("fn", globals=glob)"""
 #         a = """exec(compile(open("fn").read(), "fn", 'exec'), globals=glob)"""
 #         self.check(b, a)
-# 
+#
 #         b = """execfile("fn", locals=loc)"""
 #         a = """exec(compile(open("fn").read(), "fn", 'exec'), locals=loc)"""
 #         self.check(b, a)
-# 
+#
 #         b = """execfile("fn", globals=glob, locals=loc)"""
 #         a = """exec(compile(open("fn").read(), "fn", 'exec'), globals=glob, locals=loc)"""
 #         self.check(b, a)
-# 
+#
 #     def test_spacing(self):
 #         b = """execfile( "fn" )"""
 #         a = """exec(compile(open( "fn" ).read(), "fn", 'exec'))"""
 #         self.check(b, a)
-# 
+#
 #         b = """execfile("fn",  globals = glob)"""
 #         a = """exec(compile(open("fn").read(), "fn", 'exec'),  globals = glob)"""
 #         self.check(b, a)
-# 
-# 
+#
+#
 # class Test_isinstance(FixerTestCase):
 #     fixer = "isinstance"
-# 
+#
 #     def test_remove_multiple_items(self):
 #         b = """isinstance(x, (int, int, int))"""
 #         a = """isinstance(x, int)"""
 #         self.check(b, a)
-# 
+#
 #         b = """isinstance(x, (int, float, int, int, float))"""
 #         a = """isinstance(x, (int, float))"""
 #         self.check(b, a)
-# 
+#
 #         b = """isinstance(x, (int, float, int, int, float, str))"""
 #         a = """isinstance(x, (int, float, str))"""
 #         self.check(b, a)
-# 
+#
 #         b = """isinstance(foo() + bar(), (x(), y(), x(), int, int))"""
 #         a = """isinstance(foo() + bar(), (x(), y(), x(), int))"""
 #         self.check(b, a)
-# 
+#
 #     def test_prefix_preservation(self):
 #         b = """if    isinstance(  foo(), (  bar, bar, baz )) : pass"""
 #         a = """if    isinstance(  foo(), (  bar, baz )) : pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_unchanged(self):
 #         self.unchanged("isinstance(x, (str, int))")
-# 
+#
 # class Test_dict(FixerTestCase):
 #     fixer = "dict"
-# 
+#
 #     def test_prefix_preservation(self):
 #         b = "if   d. keys  (  )  : pass"
 #         a = "if   list(d. keys  (  ))  : pass"
 #         self.check(b, a)
-# 
+#
 #         b = "if   d. items  (  )  : pass"
 #         a = "if   list(d. items  (  ))  : pass"
 #         self.check(b, a)
-# 
+#
 #         b = "if   d. iterkeys  ( )  : pass"
 #         a = "if   iter(d. keys  ( ))  : pass"
 #         self.check(b, a)
-# 
+#
 #         b = "[i for i in    d.  iterkeys(  )  ]"
 #         a = "[i for i in    d.  keys(  )  ]"
 #         self.check(b, a)
-# 
+#
 #         b = "if   d. viewkeys  ( )  : pass"
 #         a = "if   d. keys  ( )  : pass"
 #         self.check(b, a)
-# 
+#
 #         b = "[i for i in    d.  viewkeys(  )  ]"
 #         a = "[i for i in    d.  keys(  )  ]"
 #         self.check(b, a)
-# 
+#
 #     def test_trailing_comment(self):
 #         b = "d.keys() # foo"
 #         a = "list(d.keys()) # foo"
 #         self.check(b, a)
-# 
+#
 #         b = "d.items()  # foo"
 #         a = "list(d.items())  # foo"
 #         self.check(b, a)
-# 
+#
 #         b = "d.iterkeys()  # foo"
 #         a = "iter(d.keys())  # foo"
 #         self.check(b, a)
-# 
+#
 #         b = """[i for i in d.iterkeys() # foo
 #                ]"""
 #         a = """[i for i in d.keys() # foo
 #                ]"""
 #         self.check(b, a)
-# 
+#
 #         b = """[i for i in d.iterkeys() # foo
 #                ]"""
 #         a = """[i for i in d.keys() # foo
 #                ]"""
 #         self.check(b, a)
-# 
+#
 #         b = "d.viewitems()  # foo"
 #         a = "d.items()  # foo"
 #         self.check(b, a)
-# 
+#
 #     def test_unchanged(self):
 #         for wrapper in fixer_util.consuming_calls:
 #             s = "s = %s(d.keys())" % wrapper
 #             self.unchanged(s)
-# 
+#
 #             s = "s = %s(d.values())" % wrapper
 #             self.unchanged(s)
-# 
+#
 #             s = "s = %s(d.items())" % wrapper
 #             self.unchanged(s)
-# 
+#
 #     def test_01(self):
 #         b = "d.keys()"
 #         a = "list(d.keys())"
 #         self.check(b, a)
-# 
+#
 #         b = "a[0].foo().keys()"
 #         a = "list(a[0].foo().keys())"
 #         self.check(b, a)
-# 
+#
 #     def test_02(self):
 #         b = "d.items()"
 #         a = "list(d.items())"
 #         self.check(b, a)
-# 
+#
 #     def test_03(self):
 #         b = "d.values()"
 #         a = "list(d.values())"
 #         self.check(b, a)
-# 
+#
 #     def test_04(self):
 #         b = "d.iterkeys()"
 #         a = "iter(d.keys())"
 #         self.check(b, a)
-# 
+#
 #     def test_05(self):
 #         b = "d.iteritems()"
 #         a = "iter(d.items())"
 #         self.check(b, a)
-# 
+#
 #     def test_06(self):
 #         b = "d.itervalues()"
 #         a = "iter(d.values())"
 #         self.check(b, a)
-# 
+#
 #     def test_07(self):
 #         s = "list(d.keys())"
 #         self.unchanged(s)
-# 
+#
 #     def test_08(self):
 #         s = "sorted(d.keys())"
 #         self.unchanged(s)
-# 
+#
 #     def test_09(self):
 #         b = "iter(d.keys())"
 #         a = "iter(list(d.keys()))"
 #         self.check(b, a)
-# 
+#
 #     def test_10(self):
 #         b = "foo(d.keys())"
 #         a = "foo(list(d.keys()))"
 #         self.check(b, a)
-# 
+#
 #     def test_11(self):
 #         b = "for i in d.keys(): print i"
 #         a = "for i in list(d.keys()): print i"
 #         self.check(b, a)
-# 
+#
 #     def test_12(self):
 #         b = "for i in d.iterkeys(): print i"
 #         a = "for i in d.keys(): print i"
 #         self.check(b, a)
-# 
+#
 #     def test_13(self):
 #         b = "[i for i in d.keys()]"
 #         a = "[i for i in list(d.keys())]"
 #         self.check(b, a)
-# 
+#
 #     def test_14(self):
 #         b = "[i for i in d.iterkeys()]"
 #         a = "[i for i in d.keys()]"
 #         self.check(b, a)
-# 
+#
 #     def test_15(self):
 #         b = "(i for i in d.keys())"
 #         a = "(i for i in list(d.keys()))"
 #         self.check(b, a)
-# 
+#
 #     def test_16(self):
 #         b = "(i for i in d.iterkeys())"
 #         a = "(i for i in d.keys())"
 #         self.check(b, a)
-# 
+#
 #     def test_17(self):
 #         b = "iter(d.iterkeys())"
 #         a = "iter(d.keys())"
 #         self.check(b, a)
-# 
+#
 #     def test_18(self):
 #         b = "list(d.iterkeys())"
 #         a = "list(d.keys())"
 #         self.check(b, a)
-# 
+#
 #     def test_19(self):
 #         b = "sorted(d.iterkeys())"
 #         a = "sorted(d.keys())"
 #         self.check(b, a)
-# 
+#
 #     def test_20(self):
 #         b = "foo(d.iterkeys())"
 #         a = "foo(iter(d.keys()))"
 #         self.check(b, a)
-# 
+#
 #     def test_21(self):
 #         b = "print h.iterkeys().next()"
 #         a = "print iter(h.keys()).next()"
 #         self.check(b, a)
-# 
+#
 #     def test_22(self):
 #         b = "print h.keys()[0]"
 #         a = "print list(h.keys())[0]"
 #         self.check(b, a)
-# 
+#
 #     def test_23(self):
 #         b = "print list(h.iterkeys().next())"
 #         a = "print list(iter(h.keys()).next())"
 #         self.check(b, a)
-# 
+#
 #     def test_24(self):
 #         b = "for x in h.keys()[0]: print x"
 #         a = "for x in list(h.keys())[0]: print x"
 #         self.check(b, a)
-# 
+#
 #     def test_25(self):
 #         b = "d.viewkeys()"
 #         a = "d.keys()"
 #         self.check(b, a)
-# 
+#
 #     def test_26(self):
 #         b = "d.viewitems()"
 #         a = "d.items()"
 #         self.check(b, a)
-# 
+#
 #     def test_27(self):
 #         b = "d.viewvalues()"
 #         a = "d.values()"
 #         self.check(b, a)
-# 
+#
 #     def test_14(self):
 #         b = "[i for i in d.viewkeys()]"
 #         a = "[i for i in d.keys()]"
 #         self.check(b, a)
-# 
+#
 #     def test_15(self):
 #         b = "(i for i in d.viewkeys())"
 #         a = "(i for i in d.keys())"
 #         self.check(b, a)
-# 
+#
 #     def test_17(self):
 #         b = "iter(d.viewkeys())"
 #         a = "iter(d.keys())"
 #         self.check(b, a)
-# 
+#
 #     def test_18(self):
 #         b = "list(d.viewkeys())"
 #         a = "list(d.keys())"
 #         self.check(b, a)
-# 
+#
 #     def test_19(self):
 #         b = "sorted(d.viewkeys())"
 #         a = "sorted(d.keys())"
 #         self.check(b, a)
-# 
+#
 # class Test_xrange(FixerTestCase):
 #     fixer = "xrange"
-# 
+#
 #     def test_prefix_preservation(self):
 #         b = """x =    xrange(  10  )"""
 #         a = """x =    range(  10  )"""
 #         self.check(b, a)
-# 
+#
 #         b = """x = xrange(  1  ,  10   )"""
 #         a = """x = range(  1  ,  10   )"""
 #         self.check(b, a)
-# 
+#
 #         b = """x = xrange(  0  ,  10 ,  2 )"""
 #         a = """x = range(  0  ,  10 ,  2 )"""
 #         self.check(b, a)
-# 
+#
 #     def test_single_arg(self):
 #         b = """x = xrange(10)"""
 #         a = """x = range(10)"""
 #         self.check(b, a)
-# 
+#
 #     def test_two_args(self):
 #         b = """x = xrange(1, 10)"""
 #         a = """x = range(1, 10)"""
 #         self.check(b, a)
-# 
+#
 #     def test_three_args(self):
 #         b = """x = xrange(0, 10, 2)"""
 #         a = """x = range(0, 10, 2)"""
 #         self.check(b, a)
-# 
+#
 #     def test_wrap_in_list(self):
 #         b = """x = range(10, 3, 9)"""
 #         a = """x = list(range(10, 3, 9))"""
 #         self.check(b, a)
-# 
+#
 #         b = """x = foo(range(10, 3, 9))"""
 #         a = """x = foo(list(range(10, 3, 9)))"""
 #         self.check(b, a)
-# 
+#
 #         b = """x = range(10, 3, 9) + [4]"""
 #         a = """x = list(range(10, 3, 9)) + [4]"""
 #         self.check(b, a)
-# 
+#
 #         b = """x = range(10)[::-1]"""
 #         a = """x = list(range(10))[::-1]"""
 #         self.check(b, a)
-# 
+#
 #         b = """x = range(10)  [3]"""
 #         a = """x = list(range(10))  [3]"""
 #         self.check(b, a)
-# 
+#
 #     def test_xrange_in_for(self):
 #         b = """for i in xrange(10):\n    j=i"""
 #         a = """for i in range(10):\n    j=i"""
 #         self.check(b, a)
-# 
+#
 #         b = """[i for i in xrange(10)]"""
 #         a = """[i for i in range(10)]"""
 #         self.check(b, a)
-# 
+#
 #     def test_range_in_for(self):
 #         self.unchanged("for i in range(10): pass")
 #         self.unchanged("[i for i in range(10)]")
-# 
+#
 #     def test_in_contains_test(self):
 #         self.unchanged("x in range(10, 3, 9)")
-# 
+#
 #     def test_in_consuming_context(self):
 #         for call in fixer_util.consuming_calls:
 #             self.unchanged("a = %s(range(10))" % call)
-# 
+#
 # class Test_xrange_with_reduce(FixerTestCase):
-# 
+#
 #     def setUp(self):
 #         super(Test_xrange_with_reduce, self).setUp(["xrange", "reduce"])
-# 
+#
 #     def test_double_transform(self):
 #         b = """reduce(x, xrange(5))"""
 #         a = """from functools import reduce
 # reduce(x, range(5))"""
 #         self.check(b, a)
-# 
+#
 # class Test_raw_input(FixerTestCase):
 #     fixer = "raw_input"
-# 
+#
 #     def test_prefix_preservation(self):
 #         b = """x =    raw_input(   )"""
 #         a = """x =    input(   )"""
 #         self.check(b, a)
-# 
+#
 #         b = """x = raw_input(   ''   )"""
 #         a = """x = input(   ''   )"""
 #         self.check(b, a)
-# 
+#
 #     def test_1(self):
 #         b = """x = raw_input()"""
 #         a = """x = input()"""
 #         self.check(b, a)
-# 
+#
 #     def test_2(self):
 #         b = """x = raw_input('')"""
 #         a = """x = input('')"""
 #         self.check(b, a)
-# 
+#
 #     def test_3(self):
 #         b = """x = raw_input('prompt')"""
 #         a = """x = input('prompt')"""
 #         self.check(b, a)
-# 
+#
 #     def test_4(self):
 #         b = """x = raw_input(foo(a) + 6)"""
 #         a = """x = input(foo(a) + 6)"""
 #         self.check(b, a)
-# 
+#
 #     def test_5(self):
 #         b = """x = raw_input(invite).split()"""
 #         a = """x = input(invite).split()"""
 #         self.check(b, a)
-# 
+#
 #     def test_6(self):
 #         b = """x = raw_input(invite) . split ()"""
 #         a = """x = input(invite) . split ()"""
 #         self.check(b, a)
-# 
+#
 #     def test_8(self):
 #         b = "x = int(raw_input())"
 #         a = "x = int(input())"
 #         self.check(b, a)
-# 
+#
 # class Test_funcattrs(FixerTestCase):
 #     fixer = "funcattrs"
-# 
+#
 #     attrs = ["closure", "doc", "name", "defaults", "code", "globals", "dict"]
-# 
+#
 #     def test(self):
 #         for attr in self.attrs:
 #             b = "a.func_%s" % attr
 #             a = "a.__%s__" % attr
 #             self.check(b, a)
-# 
+#
 #             b = "self.foo.func_%s.foo_bar" % attr
 #             a = "self.foo.__%s__.foo_bar" % attr
 #             self.check(b, a)
-# 
+#
 #     def test_unchanged(self):
 #         for attr in self.attrs:
 #             s = "foo(func_%s + 5)" % attr
 #             self.unchanged(s)
-# 
+#
 #             s = "f(foo.__%s__)" % attr
 #             self.unchanged(s)
-# 
+#
 #             s = "f(foo.__%s__.foo)" % attr
 #             self.unchanged(s)
-# 
+#
 # class Test_xreadlines(FixerTestCase):
 #     fixer = "xreadlines"
-# 
+#
 #     def test_call(self):
 #         b = "for x in f.xreadlines(): pass"
 #         a = "for x in f: pass"
 #         self.check(b, a)
-# 
+#
 #         b = "for x in foo().xreadlines(): pass"
 #         a = "for x in foo(): pass"
 #         self.check(b, a)
-# 
+#
 #         b = "for x in (5 + foo()).xreadlines(): pass"
 #         a = "for x in (5 + foo()): pass"
 #         self.check(b, a)
-# 
+#
 #     def test_attr_ref(self):
 #         b = "foo(f.xreadlines + 5)"
 #         a = "foo(f.__iter__ + 5)"
 #         self.check(b, a)
-# 
+#
 #         b = "foo(f().xreadlines + 5)"
 #         a = "foo(f().__iter__ + 5)"
 #         self.check(b, a)
-# 
+#
 #         b = "foo((5 + f()).xreadlines + 5)"
 #         a = "foo((5 + f()).__iter__ + 5)"
 #         self.check(b, a)
-# 
+#
 #     def test_unchanged(self):
 #         s = "for x in f.xreadlines(5): pass"
 #         self.unchanged(s)
-# 
+#
 #         s = "for x in f.xreadlines(k=5): pass"
 #         self.unchanged(s)
-# 
+#
 #         s = "for x in f.xreadlines(*k, **v): pass"
 #         self.unchanged(s)
-# 
+#
 #         s = "foo(xreadlines)"
 #         self.unchanged(s)
-# 
-# 
+#
+#
 # class ImportsFixerTests:
-# 
+#
 #     def test_import_module(self):
 #         for old, new in self.modules.items():
 #             b = "import %s" % old
 #             a = "import %s" % new
 #             self.check(b, a)
-# 
+#
 #             b = "import foo, %s, bar" % old
 #             a = "import foo, %s, bar" % new
 #             self.check(b, a)
-# 
+#
 #     def test_import_from(self):
 #         for old, new in self.modules.items():
 #             b = "from %s import foo" % old
 #             a = "from %s import foo" % new
 #             self.check(b, a)
-# 
+#
 #             b = "from %s import foo, bar" % old
 #             a = "from %s import foo, bar" % new
 #             self.check(b, a)
-# 
+#
 #             b = "from %s import (yes, no)" % old
 #             a = "from %s import (yes, no)" % new
 #             self.check(b, a)
-# 
+#
 #     def test_import_module_as(self):
 #         for old, new in self.modules.items():
 #             b = "import %s as foo_bar" % old
 #             a = "import %s as foo_bar" % new
 #             self.check(b, a)
-# 
+#
 #             b = "import %s as foo_bar" % old
 #             a = "import %s as foo_bar" % new
 #             self.check(b, a)
-# 
+#
 #     def test_import_from_as(self):
 #         for old, new in self.modules.items():
 #             b = "from %s import foo as bar" % old
 #             a = "from %s import foo as bar" % new
 #             self.check(b, a)
-# 
+#
 #     def test_star(self):
 #         for old, new in self.modules.items():
 #             b = "from %s import *" % old
 #             a = "from %s import *" % new
 #             self.check(b, a)
-# 
+#
 #     def test_import_module_usage(self):
 #         for old, new in self.modules.items():
 #             b = """
@@ -1555,7 +1555,7 @@ class Test_print(FixerTestCase):
 #                 foo(%s.bar)
 #                 """ % (new, new)
 #             self.check(b, a)
-# 
+#
 #             b = """
 #                 from %s import x
 #                 %s = 23
@@ -1565,13 +1565,13 @@ class Test_print(FixerTestCase):
 #                 %s = 23
 #                 """ % (new, old)
 #             self.check(b, a)
-# 
+#
 #             s = """
 #                 def f():
 #                     %s.method()
 #                 """ % (old,)
 #             self.unchanged(s)
-# 
+#
 #             # test nested usage
 #             b = """
 #                 import %s
@@ -1582,7 +1582,7 @@ class Test_print(FixerTestCase):
 #                 %s.bar(%s.foo)
 #                 """ % (new, new, new)
 #             self.check(b, a)
-# 
+#
 #             b = """
 #                 import %s
 #                 x.%s
@@ -1592,16 +1592,16 @@ class Test_print(FixerTestCase):
 #                 x.%s
 #                 """ % (new, old)
 #             self.check(b, a)
-# 
-# 
+#
+#
 # class Test_imports(FixerTestCase, ImportsFixerTests):
 #     fixer = "imports"
-# 
+#
 #     def test_multiple_imports(self):
 #         b = """import urlparse, cStringIO"""
 #         a = """import urllib.parse, io"""
 #         self.check(b, a)
-# 
+#
 #     def test_multiple_imports_as(self):
 #         b = """
 #             import copy_reg as bar, HTMLParser as foo, urlparse
@@ -1612,14 +1612,14 @@ class Test_print(FixerTestCase):
 #             s = urllib.parse.spam(bar.foo())
 #             """
 #         self.check(b, a)
-# 
-# 
+#
+#
 # class Test_imports2(FixerTestCase, ImportsFixerTests):
 #     fixer = "imports2"
-# 
-# 
+#
+#
 # class Test_imports_fixer_order(FixerTestCase, ImportsFixerTests):
-# 
+#
 #     def setUp(self):
 #         super(Test_imports_fixer_order, self).setUp(['imports', 'imports2'])
 #         from ..fixes.fix_imports2 import MAPPING as mapping2
@@ -1627,23 +1627,23 @@ class Test_print(FixerTestCase):
 #         from ..fixes.fix_imports import MAPPING as mapping1
 #         for key in ('dbhash', 'dumbdbm', 'dbm', 'gdbm'):
 #             self.modules[key] = mapping1[key]
-# 
+#
 #     def test_after_local_imports_refactoring(self):
 #         for fix in ("imports", "imports2"):
 #             self.fixer = fix
 #             self.assert_runs_after("import")
-# 
-# 
+#
+#
 # class Test_urllib(FixerTestCase):
 #     fixer = "urllib"
 #     from ..fixes.fix_urllib import MAPPING as modules
-# 
+#
 #     def test_import_module(self):
 #         for old, changes in self.modules.items():
 #             b = "import %s" % old
 #             a = "import %s" % ", ".join(map(itemgetter(0), changes))
 #             self.check(b, a)
-# 
+#
 #     def test_import_from(self):
 #         for old, changes in self.modules.items():
 #             all_members = []
@@ -1653,28 +1653,28 @@ class Test_print(FixerTestCase):
 #                     b = "from %s import %s" % (old, member)
 #                     a = "from %s import %s" % (new, member)
 #                     self.check(b, a)
-# 
+#
 #                     s = "from foo import %s" % member
 #                     self.unchanged(s)
-# 
+#
 #                 b = "from %s import %s" % (old, ", ".join(members))
 #                 a = "from %s import %s" % (new, ", ".join(members))
 #                 self.check(b, a)
-# 
+#
 #                 s = "from foo import %s" % ", ".join(members)
 #                 self.unchanged(s)
-# 
+#
 #             # test the breaking of a module into multiple replacements
 #             b = "from %s import %s" % (old, ", ".join(all_members))
 #             a = "\n".join(["from %s import %s" % (new, ", ".join(members))
 #                             for (new, members) in changes])
 #             self.check(b, a)
-# 
+#
 #     def test_import_module_as(self):
 #         for old in self.modules:
 #             s = "import %s as foo" % old
 #             self.warns_unchanged(s, "This module is now multiple modules")
-# 
+#
 #     def test_import_from_as(self):
 #         for old, changes in self.modules.items():
 #             for new, members in changes:
@@ -1685,12 +1685,12 @@ class Test_print(FixerTestCase):
 #                     b = "from %s import %s as blah, %s" % (old, member, member)
 #                     a = "from %s import %s as blah, %s" % (new, member, member)
 #                     self.check(b, a)
-# 
+#
 #     def test_star(self):
 #         for old in self.modules:
 #             s = "from %s import *" % old
 #             self.warns_unchanged(s, "Cannot handle star imports")
-# 
+#
 #     def test_indented(self):
 #         b = """
 # def foo():
@@ -1702,7 +1702,7 @@ class Test_print(FixerTestCase):
 #     from urllib.request import urlopen
 # """
 #         self.check(b, a)
-# 
+#
 #         b = """
 # def foo():
 #     other()
@@ -1715,9 +1715,9 @@ class Test_print(FixerTestCase):
 #     from urllib.request import urlopen
 # """
 #         self.check(b, a)
-# 
-# 
-# 
+#
+#
+#
 #     def test_import_module_usage(self):
 #         for old, changes in self.modules.items():
 #             for new, members in changes:
@@ -1742,163 +1742,163 @@ class Test_print(FixerTestCase):
 #                         %s.%s(%s.%s)
 #                         """ % (new_import, new, member, new, member)
 #                     self.check(b, a)
-# 
-# 
+#
+#
 # class Test_input(FixerTestCase):
 #     fixer = "input"
-# 
+#
 #     def test_prefix_preservation(self):
 #         b = """x =   input(   )"""
 #         a = """x =   eval(input(   ))"""
 #         self.check(b, a)
-# 
+#
 #         b = """x = input(   ''   )"""
 #         a = """x = eval(input(   ''   ))"""
 #         self.check(b, a)
-# 
+#
 #     def test_trailing_comment(self):
 #         b = """x = input()  #  foo"""
 #         a = """x = eval(input())  #  foo"""
 #         self.check(b, a)
-# 
+#
 #     def test_idempotency(self):
 #         s = """x = eval(input())"""
 #         self.unchanged(s)
-# 
+#
 #         s = """x = eval(input(''))"""
 #         self.unchanged(s)
-# 
+#
 #         s = """x = eval(input(foo(5) + 9))"""
 #         self.unchanged(s)
-# 
+#
 #     def test_1(self):
 #         b = """x = input()"""
 #         a = """x = eval(input())"""
 #         self.check(b, a)
-# 
+#
 #     def test_2(self):
 #         b = """x = input('')"""
 #         a = """x = eval(input(''))"""
 #         self.check(b, a)
-# 
+#
 #     def test_3(self):
 #         b = """x = input('prompt')"""
 #         a = """x = eval(input('prompt'))"""
 #         self.check(b, a)
-# 
+#
 #     def test_4(self):
 #         b = """x = input(foo(5) + 9)"""
 #         a = """x = eval(input(foo(5) + 9))"""
 #         self.check(b, a)
-# 
+#
 # class Test_tuple_params(FixerTestCase):
 #     fixer = "tuple_params"
-# 
+#
 #     def test_unchanged_1(self):
 #         s = """def foo(): pass"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_2(self):
 #         s = """def foo(a, b, c): pass"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_3(self):
 #         s = """def foo(a=3, b=4, c=5): pass"""
 #         self.unchanged(s)
-# 
+#
 #     def test_1(self):
 #         b = """
 #             def foo(((a, b), c)):
 #                 x = 5"""
-# 
+#
 #         a = """
 #             def foo(xxx_todo_changeme):
 #                 ((a, b), c) = xxx_todo_changeme
 #                 x = 5"""
 #         self.check(b, a)
-# 
+#
 #     def test_2(self):
 #         b = """
 #             def foo(((a, b), c), d):
 #                 x = 5"""
-# 
+#
 #         a = """
 #             def foo(xxx_todo_changeme, d):
 #                 ((a, b), c) = xxx_todo_changeme
 #                 x = 5"""
 #         self.check(b, a)
-# 
+#
 #     def test_3(self):
 #         b = """
 #             def foo(((a, b), c), d) -> e:
 #                 x = 5"""
-# 
+#
 #         a = """
 #             def foo(xxx_todo_changeme, d) -> e:
 #                 ((a, b), c) = xxx_todo_changeme
 #                 x = 5"""
 #         self.check(b, a)
-# 
+#
 #     def test_semicolon(self):
 #         b = """
 #             def foo(((a, b), c)): x = 5; y = 7"""
-# 
+#
 #         a = """
 #             def foo(xxx_todo_changeme): ((a, b), c) = xxx_todo_changeme; x = 5; y = 7"""
 #         self.check(b, a)
-# 
+#
 #     def test_keywords(self):
 #         b = """
 #             def foo(((a, b), c), d, e=5) -> z:
 #                 x = 5"""
-# 
+#
 #         a = """
 #             def foo(xxx_todo_changeme, d, e=5) -> z:
 #                 ((a, b), c) = xxx_todo_changeme
 #                 x = 5"""
 #         self.check(b, a)
-# 
+#
 #     def test_varargs(self):
 #         b = """
 #             def foo(((a, b), c), d, *vargs, **kwargs) -> z:
 #                 x = 5"""
-# 
+#
 #         a = """
 #             def foo(xxx_todo_changeme, d, *vargs, **kwargs) -> z:
 #                 ((a, b), c) = xxx_todo_changeme
 #                 x = 5"""
 #         self.check(b, a)
-# 
+#
 #     def test_multi_1(self):
 #         b = """
 #             def foo(((a, b), c), (d, e, f)) -> z:
 #                 x = 5"""
-# 
+#
 #         a = """
 #             def foo(xxx_todo_changeme, xxx_todo_changeme1) -> z:
 #                 ((a, b), c) = xxx_todo_changeme
 #                 (d, e, f) = xxx_todo_changeme1
 #                 x = 5"""
 #         self.check(b, a)
-# 
+#
 #     def test_multi_2(self):
 #         b = """
 #             def foo(x, ((a, b), c), d, (e, f, g), y) -> z:
 #                 x = 5"""
-# 
+#
 #         a = """
 #             def foo(x, xxx_todo_changeme, d, xxx_todo_changeme1, y) -> z:
 #                 ((a, b), c) = xxx_todo_changeme
 #                 (e, f, g) = xxx_todo_changeme1
 #                 x = 5"""
 #         self.check(b, a)
-# 
+#
 #     def test_docstring(self):
 #         b = """
 #             def foo(((a, b), c), (d, e, f)) -> z:
 #                 "foo foo foo foo"
 #                 x = 5"""
-# 
+#
 #         a = """
 #             def foo(xxx_todo_changeme, xxx_todo_changeme1) -> z:
 #                 "foo foo foo foo"
@@ -1906,83 +1906,83 @@ class Test_print(FixerTestCase):
 #                 (d, e, f) = xxx_todo_changeme1
 #                 x = 5"""
 #         self.check(b, a)
-# 
+#
 #     def test_lambda_no_change(self):
 #         s = """lambda x: x + 5"""
 #         self.unchanged(s)
-# 
+#
 #     def test_lambda_parens_single_arg(self):
 #         b = """lambda (x): x + 5"""
 #         a = """lambda x: x + 5"""
 #         self.check(b, a)
-# 
+#
 #         b = """lambda(x): x + 5"""
 #         a = """lambda x: x + 5"""
 #         self.check(b, a)
-# 
+#
 #         b = """lambda ((((x)))): x + 5"""
 #         a = """lambda x: x + 5"""
 #         self.check(b, a)
-# 
+#
 #         b = """lambda((((x)))): x + 5"""
 #         a = """lambda x: x + 5"""
 #         self.check(b, a)
-# 
+#
 #     def test_lambda_simple(self):
 #         b = """lambda (x, y): x + f(y)"""
 #         a = """lambda x_y: x_y[0] + f(x_y[1])"""
 #         self.check(b, a)
-# 
+#
 #         b = """lambda(x, y): x + f(y)"""
 #         a = """lambda x_y: x_y[0] + f(x_y[1])"""
 #         self.check(b, a)
-# 
+#
 #         b = """lambda (((x, y))): x + f(y)"""
 #         a = """lambda x_y: x_y[0] + f(x_y[1])"""
 #         self.check(b, a)
-# 
+#
 #         b = """lambda(((x, y))): x + f(y)"""
 #         a = """lambda x_y: x_y[0] + f(x_y[1])"""
 #         self.check(b, a)
-# 
+#
 #     def test_lambda_one_tuple(self):
 #         b = """lambda (x,): x + f(x)"""
 #         a = """lambda x1: x1[0] + f(x1[0])"""
 #         self.check(b, a)
-# 
+#
 #         b = """lambda (((x,))): x + f(x)"""
 #         a = """lambda x1: x1[0] + f(x1[0])"""
 #         self.check(b, a)
-# 
+#
 #     def test_lambda_simple_multi_use(self):
 #         b = """lambda (x, y): x + x + f(x) + x"""
 #         a = """lambda x_y: x_y[0] + x_y[0] + f(x_y[0]) + x_y[0]"""
 #         self.check(b, a)
-# 
+#
 #     def test_lambda_simple_reverse(self):
 #         b = """lambda (x, y): y + x"""
 #         a = """lambda x_y: x_y[1] + x_y[0]"""
 #         self.check(b, a)
-# 
+#
 #     def test_lambda_nested(self):
 #         b = """lambda (x, (y, z)): x + y + z"""
 #         a = """lambda x_y_z: x_y_z[0] + x_y_z[1][0] + x_y_z[1][1]"""
 #         self.check(b, a)
-# 
+#
 #         b = """lambda (((x, (y, z)))): x + y + z"""
 #         a = """lambda x_y_z: x_y_z[0] + x_y_z[1][0] + x_y_z[1][1]"""
 #         self.check(b, a)
-# 
+#
 #     def test_lambda_nested_multi_use(self):
 #         b = """lambda (x, (y, z)): x + y + f(y)"""
 #         a = """lambda x_y_z: x_y_z[0] + x_y_z[1][0] + f(x_y_z[1][0])"""
 #         self.check(b, a)
-# 
+#
 # class Test_methodattrs(FixerTestCase):
 #     fixer = "methodattrs"
-# 
+#
 #     attrs = ["func", "self", "class"]
-# 
+#
 #     def test(self):
 #         for attr in self.attrs:
 #             b = "a.im_%s" % attr
@@ -1991,58 +1991,58 @@ class Test_print(FixerTestCase):
 #             else:
 #                 a = "a.__%s__" % attr
 #             self.check(b, a)
-# 
+#
 #             b = "self.foo.im_%s.foo_bar" % attr
 #             if attr == "class":
 #                 a = "self.foo.__self__.__class__.foo_bar"
 #             else:
 #                 a = "self.foo.__%s__.foo_bar" % attr
 #             self.check(b, a)
-# 
+#
 #     def test_unchanged(self):
 #         for attr in self.attrs:
 #             s = "foo(im_%s + 5)" % attr
 #             self.unchanged(s)
-# 
+#
 #             s = "f(foo.__%s__)" % attr
 #             self.unchanged(s)
-# 
+#
 #             s = "f(foo.__%s__.foo)" % attr
 #             self.unchanged(s)
-# 
+#
 # class Test_next(FixerTestCase):
 #     fixer = "next"
-# 
+#
 #     def test_1(self):
 #         b = """it.next()"""
 #         a = """next(it)"""
 #         self.check(b, a)
-# 
+#
 #     def test_2(self):
 #         b = """a.b.c.d.next()"""
 #         a = """next(a.b.c.d)"""
 #         self.check(b, a)
-# 
+#
 #     def test_3(self):
 #         b = """(a + b).next()"""
 #         a = """next((a + b))"""
 #         self.check(b, a)
-# 
+#
 #     def test_4(self):
 #         b = """a().next()"""
 #         a = """next(a())"""
 #         self.check(b, a)
-# 
+#
 #     def test_5(self):
 #         b = """a().next() + b"""
 #         a = """next(a()) + b"""
 #         self.check(b, a)
-# 
+#
 #     def test_6(self):
 #         b = """c(      a().next() + b)"""
 #         a = """c(      next(a()) + b)"""
 #         self.check(b, a)
-# 
+#
 #     def test_prefix_preservation_1(self):
 #         b = """
 #             for a in b:
@@ -2055,7 +2055,7 @@ class Test_print(FixerTestCase):
 #                 next(a)
 #             """
 #         self.check(b, a)
-# 
+#
 #     def test_prefix_preservation_2(self):
 #         b = """
 #             for a in b:
@@ -2070,7 +2070,7 @@ class Test_print(FixerTestCase):
 #                 next(a)
 #             """
 #         self.check(b, a)
-# 
+#
 #     def test_prefix_preservation_3(self):
 #         b = """
 #             next = 5
@@ -2085,7 +2085,7 @@ class Test_print(FixerTestCase):
 #                 a.__next__()
 #             """
 #         self.check(b, a, ignore_warnings=True)
-# 
+#
 #     def test_prefix_preservation_4(self):
 #         b = """
 #             next = 5
@@ -2102,7 +2102,7 @@ class Test_print(FixerTestCase):
 #                 a.__next__()
 #             """
 #         self.check(b, a, ignore_warnings=True)
-# 
+#
 #     def test_prefix_preservation_5(self):
 #         b = """
 #             next = 5
@@ -2117,7 +2117,7 @@ class Test_print(FixerTestCase):
 #                     a.__next__())
 #             """
 #         self.check(b, a, ignore_warnings=True)
-# 
+#
 #     def test_prefix_preservation_6(self):
 #         b = """
 #             for a in b:
@@ -2130,7 +2130,7 @@ class Test_print(FixerTestCase):
 #                     next(a))
 #             """
 #         self.check(b, a)
-# 
+#
 #     def test_method_1(self):
 #         b = """
 #             class A:
@@ -2143,7 +2143,7 @@ class Test_print(FixerTestCase):
 #                     pass
 #             """
 #         self.check(b, a)
-# 
+#
 #     def test_method_2(self):
 #         b = """
 #             class A(object):
@@ -2156,7 +2156,7 @@ class Test_print(FixerTestCase):
 #                     pass
 #             """
 #         self.check(b, a)
-# 
+#
 #     def test_method_3(self):
 #         b = """
 #             class A:
@@ -2169,16 +2169,16 @@ class Test_print(FixerTestCase):
 #                     pass
 #             """
 #         self.check(b, a)
-# 
+#
 #     def test_method_4(self):
 #         b = """
 #             class A:
 #                 def __init__(self, foo):
 #                     self.foo = foo
-# 
+#
 #                 def next(self):
 #                     pass
-# 
+#
 #                 def __iter__(self):
 #                     return self
 #             """
@@ -2186,15 +2186,15 @@ class Test_print(FixerTestCase):
 #             class A:
 #                 def __init__(self, foo):
 #                     self.foo = foo
-# 
+#
 #                 def __next__(self):
 #                     pass
-# 
+#
 #                 def __iter__(self):
 #                     return self
 #             """
 #         self.check(b, a)
-# 
+#
 #     def test_method_unchanged(self):
 #         s = """
 #             class A:
@@ -2202,227 +2202,227 @@ class Test_print(FixerTestCase):
 #                     pass
 #             """
 #         self.unchanged(s)
-# 
+#
 #     def test_shadowing_assign_simple(self):
 #         s = """
 #             next = foo
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_shadowing_assign_tuple_1(self):
 #         s = """
 #             (next, a) = foo
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_shadowing_assign_tuple_2(self):
 #         s = """
 #             (a, (b, (next, c)), a) = foo
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_shadowing_assign_list_1(self):
 #         s = """
 #             [next, a] = foo
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_shadowing_assign_list_2(self):
 #         s = """
 #             [a, [b, [next, c]], a] = foo
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_builtin_assign(self):
 #         s = """
 #             def foo():
 #                 __builtin__.next = foo
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_builtin_assign_in_tuple(self):
 #         s = """
 #             def foo():
 #                 (a, __builtin__.next) = foo
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_builtin_assign_in_list(self):
 #         s = """
 #             def foo():
 #                 [a, __builtin__.next] = foo
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_assign_to_next(self):
 #         s = """
 #             def foo():
 #                 A.next = foo
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.unchanged(s)
-# 
+#
 #     def test_assign_to_next_in_tuple(self):
 #         s = """
 #             def foo():
 #                 (a, A.next) = foo
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.unchanged(s)
-# 
+#
 #     def test_assign_to_next_in_list(self):
 #         s = """
 #             def foo():
 #                 [a, A.next] = foo
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.unchanged(s)
-# 
+#
 #     def test_shadowing_import_1(self):
 #         s = """
 #             import foo.bar as next
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_shadowing_import_2(self):
 #         s = """
 #             import bar, bar.foo as next
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_shadowing_import_3(self):
 #         s = """
 #             import bar, bar.foo as next, baz
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_shadowing_import_from_1(self):
 #         s = """
 #             from x import next
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_shadowing_import_from_2(self):
 #         s = """
 #             from x.a import next
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_shadowing_import_from_3(self):
 #         s = """
 #             from x import a, next, b
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_shadowing_import_from_4(self):
 #         s = """
 #             from x.a import a, next, b
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_shadowing_funcdef_1(self):
 #         s = """
 #             def next(a):
 #                 pass
-# 
+#
 #             class A:
 #                 def next(self, a, b):
 #                     pass
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_shadowing_funcdef_2(self):
 #         b = """
 #             def next(a):
 #                 pass
-# 
+#
 #             class A:
 #                 def next(self):
 #                     pass
-# 
+#
 #             it.next()
 #             """
 #         a = """
 #             def next(a):
 #                 pass
-# 
+#
 #             class A:
 #                 def __next__(self):
 #                     pass
-# 
+#
 #             it.__next__()
 #             """
 #         self.warns(b, a, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_shadowing_global_1(self):
 #         s = """
 #             def f():
@@ -2430,7 +2430,7 @@ class Test_print(FixerTestCase):
 #                 next = 5
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_shadowing_global_2(self):
 #         s = """
 #             def f():
@@ -2438,55 +2438,55 @@ class Test_print(FixerTestCase):
 #                 next = 5
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_shadowing_for_simple(self):
 #         s = """
 #             for next in it():
 #                 pass
-# 
+#
 #             b = 5
 #             c = 6
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_shadowing_for_tuple_1(self):
 #         s = """
 #             for next, b in it():
 #                 pass
-# 
+#
 #             b = 5
 #             c = 6
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_shadowing_for_tuple_2(self):
 #         s = """
 #             for a, (next, c), b in it():
 #                 pass
-# 
+#
 #             b = 5
 #             c = 6
 #             """
 #         self.warns_unchanged(s, "Calls to builtin next() possibly shadowed")
-# 
+#
 #     def test_noncall_access_1(self):
 #         b = """gnext = g.next"""
 #         a = """gnext = g.__next__"""
 #         self.check(b, a)
-# 
+#
 #     def test_noncall_access_2(self):
 #         b = """f(g.next + 5)"""
 #         a = """f(g.__next__ + 5)"""
 #         self.check(b, a)
-# 
+#
 #     def test_noncall_access_3(self):
 #         b = """f(g().next + 5)"""
 #         a = """f(g().__next__ + 5)"""
 #         self.check(b, a)
-# 
+#
 # class Test_nonzero(FixerTestCase):
 #     fixer = "nonzero"
-# 
+#
 #     def test_1(self):
 #         b = """
 #             class A:
@@ -2499,7 +2499,7 @@ class Test_print(FixerTestCase):
 #                     pass
 #             """
 #         self.check(b, a)
-# 
+#
 #     def test_2(self):
 #         b = """
 #             class A(object):
@@ -2512,7 +2512,7 @@ class Test_print(FixerTestCase):
 #                     pass
 #             """
 #         self.check(b, a)
-# 
+#
 #     def test_unchanged_1(self):
 #         s = """
 #             class A(object):
@@ -2520,7 +2520,7 @@ class Test_print(FixerTestCase):
 #                     pass
 #             """
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_2(self):
 #         s = """
 #             class A(object):
@@ -2528,101 +2528,101 @@ class Test_print(FixerTestCase):
 #                     pass
 #             """
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_func(self):
 #         s = """
 #             def __nonzero__(self):
 #                 pass
 #             """
 #         self.unchanged(s)
-# 
+#
 # class Test_numliterals(FixerTestCase):
 #     fixer = "numliterals"
-# 
+#
 #     def test_octal_1(self):
 #         b = """0755"""
 #         a = """0o755"""
 #         self.check(b, a)
-# 
+#
 #     def test_long_int_1(self):
 #         b = """a = 12L"""
 #         a = """a = 12"""
 #         self.check(b, a)
-# 
+#
 #     def test_long_int_2(self):
 #         b = """a = 12l"""
 #         a = """a = 12"""
 #         self.check(b, a)
-# 
+#
 #     def test_long_hex(self):
 #         b = """b = 0x12l"""
 #         a = """b = 0x12"""
 #         self.check(b, a)
-# 
+#
 #     def test_comments_and_spacing(self):
 #         b = """b =   0x12L"""
 #         a = """b =   0x12"""
 #         self.check(b, a)
-# 
+#
 #         b = """b = 0755 # spam"""
 #         a = """b = 0o755 # spam"""
 #         self.check(b, a)
-# 
+#
 #     def test_unchanged_int(self):
 #         s = """5"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_float(self):
 #         s = """5.0"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_octal(self):
 #         s = """0o755"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_hex(self):
 #         s = """0xABC"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_exp(self):
 #         s = """5.0e10"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_complex_int(self):
 #         s = """5 + 4j"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_complex_float(self):
 #         s = """5.4 + 4.9j"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_complex_bare(self):
 #         s = """4j"""
 #         self.unchanged(s)
 #         s = """4.4j"""
 #         self.unchanged(s)
-# 
+#
 # class Test_renames(FixerTestCase):
 #     fixer = "renames"
-# 
+#
 #     modules = {"sys":  ("maxint", "maxsize"),
 #               }
-# 
+#
 #     def test_import_from(self):
 #         for mod, (old, new) in self.modules.items():
 #             b = "from %s import %s" % (mod, old)
 #             a = "from %s import %s" % (mod, new)
 #             self.check(b, a)
-# 
+#
 #             s = "from foo import %s" % old
 #             self.unchanged(s)
-# 
+#
 #     def test_import_from_as(self):
 #         for mod, (old, new) in self.modules.items():
 #             b = "from %s import %s as foo_bar" % (mod, old)
 #             a = "from %s import %s as foo_bar" % (mod, new)
 #             self.check(b, a)
-# 
+#
 #     def test_import_module_usage(self):
 #         for mod, (old, new) in self.modules.items():
 #             b = """
@@ -2634,7 +2634,7 @@ class Test_print(FixerTestCase):
 #                 foo(%s, %s.%s)
 #                 """ % (mod, mod, mod, new)
 #             self.check(b, a)
-# 
+#
 #     def XXX_test_from_import_usage(self):
 #         # not implemented yet
 #         for mod, (old, new) in self.modules.items():
@@ -2647,66 +2647,66 @@ class Test_print(FixerTestCase):
 #                 foo(%s, %s)
 #                 """ % (mod, new, mod, new)
 #             self.check(b, a)
-# 
+#
 # class Test_unicode(FixerTestCase):
 #     fixer = "unicode"
-# 
+#
 #     def test_whitespace(self):
 #         b = """unicode( x)"""
 #         a = """str( x)"""
 #         self.check(b, a)
-# 
+#
 #         b = """ unicode(x )"""
 #         a = """ str(x )"""
 #         self.check(b, a)
-# 
+#
 #         b = """ u'h'"""
 #         a = """ 'h'"""
 #         self.check(b, a)
-# 
+#
 #     def test_unicode_call(self):
 #         b = """unicode(x, y, z)"""
 #         a = """str(x, y, z)"""
 #         self.check(b, a)
-# 
+#
 #     def test_unichr(self):
 #         b = """unichr(u'h')"""
 #         a = """chr('h')"""
 #         self.check(b, a)
-# 
+#
 #     def test_unicode_literal_1(self):
 #         b = '''u"x"'''
 #         a = '''"x"'''
 #         self.check(b, a)
-# 
+#
 #     def test_unicode_literal_2(self):
 #         b = """ur'x'"""
 #         a = """r'x'"""
 #         self.check(b, a)
-# 
+#
 #     def test_unicode_literal_3(self):
 #         b = """UR'''x''' """
 #         a = """R'''x''' """
 #         self.check(b, a)
-# 
+#
 # class Test_callable(FixerTestCase):
 #     fixer = "callable"
-# 
+#
 #     def test_prefix_preservation(self):
 #         b = """callable(    x)"""
 #         a = """import collections\nisinstance(    x, collections.Callable)"""
 #         self.check(b, a)
-# 
+#
 #         b = """if     callable(x): pass"""
 #         a = """import collections
 # if     isinstance(x, collections.Callable): pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_callable_call(self):
 #         b = """callable(x)"""
 #         a = """import collections\nisinstance(x, collections.Callable)"""
 #         self.check(b, a)
-# 
+#
 #     def test_global_import(self):
 #         b = """
 # def spam(foo):
@@ -2716,14 +2716,14 @@ class Test_print(FixerTestCase):
 # def spam(foo):
 #     isinstance(foo, collections.Callable)"""[1:]
 #         self.check(b, a)
-# 
+#
 #         b = """
 # import collections
 # def spam(foo):
 #     callable(foo)"""[1:]
 #         # same output if it was already imported
 #         self.check(b, a)
-# 
+#
 #         b = """
 # from collections import *
 # def spam(foo):
@@ -2734,7 +2734,7 @@ class Test_print(FixerTestCase):
 # def spam(foo):
 #     isinstance(foo, collections.Callable)"""[1:]
 #         self.check(b, a)
-# 
+#
 #         b = """
 # do_stuff()
 # do_some_other_stuff()
@@ -2745,7 +2745,7 @@ class Test_print(FixerTestCase):
 # do_some_other_stuff()
 # assert isinstance(do_stuff, collections.Callable)"""[1:]
 #         self.check(b, a)
-# 
+#
 #         b = """
 # if isinstance(do_stuff, Callable):
 #     assert callable(do_stuff)
@@ -2768,55 +2768,55 @@ class Test_print(FixerTestCase):
 # else:
 #     assert not isinstance(do_stuff, collections.Callable)"""[1:]
 #         self.check(b, a)
-# 
+#
 #     def test_callable_should_not_change(self):
 #         a = """callable(*x)"""
 #         self.unchanged(a)
-# 
+#
 #         a = """callable(x, y)"""
 #         self.unchanged(a)
-# 
+#
 #         a = """callable(x, kw=y)"""
 #         self.unchanged(a)
-# 
+#
 #         a = """callable()"""
 #         self.unchanged(a)
-# 
+#
 # class Test_filter(FixerTestCase):
 #     fixer = "filter"
-# 
+#
 #     def test_prefix_preservation(self):
 #         b = """x =   filter(    foo,     'abc'   )"""
 #         a = """x =   list(filter(    foo,     'abc'   ))"""
 #         self.check(b, a)
-# 
+#
 #         b = """x =   filter(  None , 'abc'  )"""
 #         a = """x =   [_f for _f in 'abc' if _f]"""
 #         self.check(b, a)
-# 
+#
 #     def test_filter_basic(self):
 #         b = """x = filter(None, 'abc')"""
 #         a = """x = [_f for _f in 'abc' if _f]"""
 #         self.check(b, a)
-# 
+#
 #         b = """x = len(filter(f, 'abc'))"""
 #         a = """x = len(list(filter(f, 'abc')))"""
 #         self.check(b, a)
-# 
+#
 #         b = """x = filter(lambda x: x%2 == 0, range(10))"""
 #         a = """x = [x for x in range(10) if x%2 == 0]"""
 #         self.check(b, a)
-# 
+#
 #         # Note the parens around x
 #         b = """x = filter(lambda (x): x%2 == 0, range(10))"""
 #         a = """x = [x for x in range(10) if x%2 == 0]"""
 #         self.check(b, a)
-# 
+#
 #         # XXX This (rare) case is not supported
 # ##         b = """x = filter(f, 'abc')[0]"""
 # ##         a = """x = list(filter(f, 'abc'))[0]"""
 # ##         self.check(b, a)
-# 
+#
 #     def test_filter_nochange(self):
 #         a = """b.join(filter(f, 'abc'))"""
 #         self.unchanged(a)
@@ -2856,62 +2856,62 @@ class Test_print(FixerTestCase):
 #         self.unchanged(a)
 #         a = """(x for x in filter(f, 'abc'))"""
 #         self.unchanged(a)
-# 
+#
 #     def test_future_builtins(self):
 #         a = "from future_builtins import spam, filter; filter(f, 'ham')"
 #         self.unchanged(a)
-# 
+#
 #         b = """from future_builtins import spam; x = filter(f, 'abc')"""
 #         a = """from future_builtins import spam; x = list(filter(f, 'abc'))"""
 #         self.check(b, a)
-# 
+#
 #         a = "from future_builtins import *; filter(f, 'ham')"
 #         self.unchanged(a)
-# 
+#
 # class Test_map(FixerTestCase):
 #     fixer = "map"
-# 
+#
 #     def check(self, b, a):
 #         self.unchanged("from future_builtins import map; " + b, a)
 #         super(Test_map, self).check(b, a)
-# 
+#
 #     def test_prefix_preservation(self):
 #         b = """x =    map(   f,    'abc'   )"""
 #         a = """x =    list(map(   f,    'abc'   ))"""
 #         self.check(b, a)
-# 
+#
 #     def test_trailing_comment(self):
 #         b = """x = map(f, 'abc')   #   foo"""
 #         a = """x = list(map(f, 'abc'))   #   foo"""
 #         self.check(b, a)
-# 
+#
 #     def test_None_with_multiple_arguments(self):
 #         s = """x = map(None, a, b, c)"""
 #         self.warns_unchanged(s, "cannot convert map(None, ...) with "
 #                              "multiple arguments")
-# 
+#
 #     def test_map_basic(self):
 #         b = """x = map(f, 'abc')"""
 #         a = """x = list(map(f, 'abc'))"""
 #         self.check(b, a)
-# 
+#
 #         b = """x = len(map(f, 'abc', 'def'))"""
 #         a = """x = len(list(map(f, 'abc', 'def')))"""
 #         self.check(b, a)
-# 
+#
 #         b = """x = map(None, 'abc')"""
 #         a = """x = list('abc')"""
 #         self.check(b, a)
-# 
+#
 #         b = """x = map(lambda x: x+1, range(4))"""
 #         a = """x = [x+1 for x in range(4)]"""
 #         self.check(b, a)
-# 
+#
 #         # Note the parens around x
 #         b = """x = map(lambda (x): x+1, range(4))"""
 #         a = """x = [x+1 for x in range(4)]"""
 #         self.check(b, a)
-# 
+#
 #         b = """
 #             foo()
 #             # foo
@@ -2923,12 +2923,12 @@ class Test_print(FixerTestCase):
 #             list(map(f, x))
 #             """
 #         self.warns(b, a, "You should use a for loop here")
-# 
+#
 #         # XXX This (rare) case is not supported
 # ##         b = """x = map(f, 'abc')[0]"""
 # ##         a = """x = list(map(f, 'abc'))[0]"""
 # ##         self.check(b, a)
-# 
+#
 #     def test_map_nochange(self):
 #         a = """b.join(map(f, 'abc'))"""
 #         self.unchanged(a)
@@ -2968,34 +2968,34 @@ class Test_print(FixerTestCase):
 #         self.unchanged(a)
 #         a = """(x for x in map(f, 'abc'))"""
 #         self.unchanged(a)
-# 
+#
 #     def test_future_builtins(self):
 #         a = "from future_builtins import spam, map, eggs; map(f, 'ham')"
 #         self.unchanged(a)
-# 
+#
 #         b = """from future_builtins import spam, eggs; x = map(f, 'abc')"""
 #         a = """from future_builtins import spam, eggs; x = list(map(f, 'abc'))"""
 #         self.check(b, a)
-# 
+#
 #         a = "from future_builtins import *; map(f, 'ham')"
 #         self.unchanged(a)
-# 
+#
 # class Test_zip(FixerTestCase):
 #     fixer = "zip"
-# 
+#
 #     def check(self, b, a):
 #         self.unchanged("from future_builtins import zip; " + b, a)
 #         super(Test_zip, self).check(b, a)
-# 
+#
 #     def test_zip_basic(self):
 #         b = """x = zip(a, b, c)"""
 #         a = """x = list(zip(a, b, c))"""
 #         self.check(b, a)
-# 
+#
 #         b = """x = len(zip(a, b))"""
 #         a = """x = len(list(zip(a, b)))"""
 #         self.check(b, a)
-# 
+#
 #     def test_zip_nochange(self):
 #         a = """b.join(zip(a, b))"""
 #         self.unchanged(a)
@@ -3035,74 +3035,74 @@ class Test_print(FixerTestCase):
 #         self.unchanged(a)
 #         a = """(x for x in zip(a, b))"""
 #         self.unchanged(a)
-# 
+#
 #     def test_future_builtins(self):
 #         a = "from future_builtins import spam, zip, eggs; zip(a, b)"
 #         self.unchanged(a)
-# 
+#
 #         b = """from future_builtins import spam, eggs; x = zip(a, b)"""
 #         a = """from future_builtins import spam, eggs; x = list(zip(a, b))"""
 #         self.check(b, a)
-# 
+#
 #         a = "from future_builtins import *; zip(a, b)"
 #         self.unchanged(a)
-# 
+#
 # class Test_standarderror(FixerTestCase):
 #     fixer = "standarderror"
-# 
+#
 #     def test(self):
 #         b = """x =    StandardError()"""
 #         a = """x =    Exception()"""
 #         self.check(b, a)
-# 
+#
 #         b = """x = StandardError(a, b, c)"""
 #         a = """x = Exception(a, b, c)"""
 #         self.check(b, a)
-# 
+#
 #         b = """f(2 + StandardError(a, b, c))"""
 #         a = """f(2 + Exception(a, b, c))"""
 #         self.check(b, a)
-# 
+#
 # class Test_types(FixerTestCase):
 #     fixer = "types"
-# 
+#
 #     def test_basic_types_convert(self):
 #         b = """types.StringType"""
 #         a = """bytes"""
 #         self.check(b, a)
-# 
+#
 #         b = """types.DictType"""
 #         a = """dict"""
 #         self.check(b, a)
-# 
+#
 #         b = """types . IntType"""
 #         a = """int"""
 #         self.check(b, a)
-# 
+#
 #         b = """types.ListType"""
 #         a = """list"""
 #         self.check(b, a)
-# 
+#
 #         b = """types.LongType"""
 #         a = """int"""
 #         self.check(b, a)
-# 
+#
 #         b = """types.NoneType"""
 #         a = """type(None)"""
 #         self.check(b, a)
-# 
+#
 # class Test_idioms(FixerTestCase):
 #     fixer = "idioms"
-# 
+#
 #     def test_while(self):
 #         b = """while 1: foo()"""
 #         a = """while True: foo()"""
 #         self.check(b, a)
-# 
+#
 #         b = """while   1: foo()"""
 #         a = """while   True: foo()"""
 #         self.check(b, a)
-# 
+#
 #         b = """
 #             while 1:
 #                 foo()
@@ -3112,132 +3112,132 @@ class Test_print(FixerTestCase):
 #                 foo()
 #             """
 #         self.check(b, a)
-# 
+#
 #     def test_while_unchanged(self):
 #         s = """while 11: foo()"""
 #         self.unchanged(s)
-# 
+#
 #         s = """while 0: foo()"""
 #         self.unchanged(s)
-# 
+#
 #         s = """while foo(): foo()"""
 #         self.unchanged(s)
-# 
+#
 #         s = """while []: foo()"""
 #         self.unchanged(s)
-# 
+#
 #     def test_eq_simple(self):
 #         b = """type(x) == T"""
 #         a = """isinstance(x, T)"""
 #         self.check(b, a)
-# 
+#
 #         b = """if   type(x) == T: pass"""
 #         a = """if   isinstance(x, T): pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_eq_reverse(self):
 #         b = """T == type(x)"""
 #         a = """isinstance(x, T)"""
 #         self.check(b, a)
-# 
+#
 #         b = """if   T == type(x): pass"""
 #         a = """if   isinstance(x, T): pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_eq_expression(self):
 #         b = """type(x+y) == d.get('T')"""
 #         a = """isinstance(x+y, d.get('T'))"""
 #         self.check(b, a)
-# 
+#
 #         b = """type(   x  +  y) == d.get('T')"""
 #         a = """isinstance(x  +  y, d.get('T'))"""
 #         self.check(b, a)
-# 
+#
 #     def test_is_simple(self):
 #         b = """type(x) is T"""
 #         a = """isinstance(x, T)"""
 #         self.check(b, a)
-# 
+#
 #         b = """if   type(x) is T: pass"""
 #         a = """if   isinstance(x, T): pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_is_reverse(self):
 #         b = """T is type(x)"""
 #         a = """isinstance(x, T)"""
 #         self.check(b, a)
-# 
+#
 #         b = """if   T is type(x): pass"""
 #         a = """if   isinstance(x, T): pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_is_expression(self):
 #         b = """type(x+y) is d.get('T')"""
 #         a = """isinstance(x+y, d.get('T'))"""
 #         self.check(b, a)
-# 
+#
 #         b = """type(   x  +  y) is d.get('T')"""
 #         a = """isinstance(x  +  y, d.get('T'))"""
 #         self.check(b, a)
-# 
+#
 #     def test_is_not_simple(self):
 #         b = """type(x) is not T"""
 #         a = """not isinstance(x, T)"""
 #         self.check(b, a)
-# 
+#
 #         b = """if   type(x) is not T: pass"""
 #         a = """if   not isinstance(x, T): pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_is_not_reverse(self):
 #         b = """T is not type(x)"""
 #         a = """not isinstance(x, T)"""
 #         self.check(b, a)
-# 
+#
 #         b = """if   T is not type(x): pass"""
 #         a = """if   not isinstance(x, T): pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_is_not_expression(self):
 #         b = """type(x+y) is not d.get('T')"""
 #         a = """not isinstance(x+y, d.get('T'))"""
 #         self.check(b, a)
-# 
+#
 #         b = """type(   x  +  y) is not d.get('T')"""
 #         a = """not isinstance(x  +  y, d.get('T'))"""
 #         self.check(b, a)
-# 
+#
 #     def test_ne_simple(self):
 #         b = """type(x) != T"""
 #         a = """not isinstance(x, T)"""
 #         self.check(b, a)
-# 
+#
 #         b = """if   type(x) != T: pass"""
 #         a = """if   not isinstance(x, T): pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_ne_reverse(self):
 #         b = """T != type(x)"""
 #         a = """not isinstance(x, T)"""
 #         self.check(b, a)
-# 
+#
 #         b = """if   T != type(x): pass"""
 #         a = """if   not isinstance(x, T): pass"""
 #         self.check(b, a)
-# 
+#
 #     def test_ne_expression(self):
 #         b = """type(x+y) != d.get('T')"""
 #         a = """not isinstance(x+y, d.get('T'))"""
 #         self.check(b, a)
-# 
+#
 #         b = """type(   x  +  y) != d.get('T')"""
 #         a = """not isinstance(x  +  y, d.get('T'))"""
 #         self.check(b, a)
-# 
+#
 #     def test_type_unchanged(self):
 #         a = """type(x).__name__"""
 #         self.unchanged(a)
-# 
+#
 #     def test_sort_list_call(self):
 #         b = """
 #             v = list(t)
@@ -3249,7 +3249,7 @@ class Test_print(FixerTestCase):
 #             foo(v)
 #             """
 #         self.check(b, a)
-# 
+#
 #         b = """
 #             v = list(foo(b) + d)
 #             v.sort()
@@ -3260,7 +3260,7 @@ class Test_print(FixerTestCase):
 #             foo(v)
 #             """
 #         self.check(b, a)
-# 
+#
 #         b = """
 #             while x:
 #                 v = list(t)
@@ -3273,7 +3273,7 @@ class Test_print(FixerTestCase):
 #                 foo(v)
 #             """
 #         self.check(b, a)
-# 
+#
 #         b = """
 #             v = list(t)
 #             # foo
@@ -3286,7 +3286,7 @@ class Test_print(FixerTestCase):
 #             foo(v)
 #             """
 #         self.check(b, a)
-# 
+#
 #         b = r"""
 #             v = list(   t)
 #             v.sort()
@@ -3297,21 +3297,21 @@ class Test_print(FixerTestCase):
 #             foo(v)
 #             """
 #         self.check(b, a)
-# 
+#
 #         b = r"""
 #             try:
 #                 m = list(s)
 #                 m.sort()
 #             except: pass
 #             """
-# 
+#
 #         a = r"""
 #             try:
 #                 m = sorted(s)
 #             except: pass
 #             """
 #         self.check(b, a)
-# 
+#
 #         b = r"""
 #             try:
 #                 m = list(s)
@@ -3319,7 +3319,7 @@ class Test_print(FixerTestCase):
 #                 m.sort()
 #             except: pass
 #             """
-# 
+#
 #         a = r"""
 #             try:
 #                 m = sorted(s)
@@ -3327,17 +3327,17 @@ class Test_print(FixerTestCase):
 #             except: pass
 #             """
 #         self.check(b, a)
-# 
+#
 #         b = r"""
 #             m = list(s)
 #             # more comments
 #             m.sort()"""
-# 
+#
 #         a = r"""
 #             m = sorted(s)
 #             # more comments"""
 #         self.check(b, a)
-# 
+#
 #     def test_sort_simple_expr(self):
 #         b = """
 #             v = t
@@ -3349,7 +3349,7 @@ class Test_print(FixerTestCase):
 #             foo(v)
 #             """
 #         self.check(b, a)
-# 
+#
 #         b = """
 #             v = foo(b)
 #             v.sort()
@@ -3360,7 +3360,7 @@ class Test_print(FixerTestCase):
 #             foo(v)
 #             """
 #         self.check(b, a)
-# 
+#
 #         b = """
 #             v = b.keys()
 #             v.sort()
@@ -3371,7 +3371,7 @@ class Test_print(FixerTestCase):
 #             foo(v)
 #             """
 #         self.check(b, a)
-# 
+#
 #         b = """
 #             v = foo(b) + d
 #             v.sort()
@@ -3382,7 +3382,7 @@ class Test_print(FixerTestCase):
 #             foo(v)
 #             """
 #         self.check(b, a)
-# 
+#
 #         b = """
 #             while x:
 #                 v = t
@@ -3395,7 +3395,7 @@ class Test_print(FixerTestCase):
 #                 foo(v)
 #             """
 #         self.check(b, a)
-# 
+#
 #         b = """
 #             v = t
 #             # foo
@@ -3408,7 +3408,7 @@ class Test_print(FixerTestCase):
 #             foo(v)
 #             """
 #         self.check(b, a)
-# 
+#
 #         b = r"""
 #             v =   t
 #             v.sort()
@@ -3419,7 +3419,7 @@ class Test_print(FixerTestCase):
 #             foo(v)
 #             """
 #         self.check(b, a)
-# 
+#
 #     def test_sort_unchanged(self):
 #         s = """
 #             v = list(t)
@@ -3427,57 +3427,57 @@ class Test_print(FixerTestCase):
 #             foo(w)
 #             """
 #         self.unchanged(s)
-# 
+#
 #         s = """
 #             v = list(t)
 #             v.sort(u)
 #             foo(v)
 #             """
 #         self.unchanged(s)
-# 
+#
 # class Test_basestring(FixerTestCase):
 #     fixer = "basestring"
-# 
+#
 #     def test_basestring(self):
 #         b = """isinstance(x, basestring)"""
 #         a = """isinstance(x, str)"""
 #         self.check(b, a)
-# 
+#
 # class Test_buffer(FixerTestCase):
 #     fixer = "buffer"
-# 
+#
 #     def test_buffer(self):
 #         b = """x = buffer(y)"""
 #         a = """x = memoryview(y)"""
 #         self.check(b, a)
-# 
+#
 #     def test_slicing(self):
 #         b = """buffer(y)[4:5]"""
 #         a = """memoryview(y)[4:5]"""
 #         self.check(b, a)
-# 
+#
 # class Test_future(FixerTestCase):
 #     fixer = "future"
-# 
+#
 #     def test_future(self):
 #         b = """from __future__ import braces"""
 #         a = """"""
 #         self.check(b, a)
-# 
+#
 #         b = """# comment\nfrom __future__ import braces"""
 #         a = """# comment\n"""
 #         self.check(b, a)
-# 
+#
 #         b = """from __future__ import braces\n# comment"""
 #         a = """\n# comment"""
 #         self.check(b, a)
-# 
+#
 #     def test_run_order(self):
 #         self.assert_runs_after('print')
-# 
+#
 # class Test_itertools(FixerTestCase):
 #     fixer = "itertools"
-# 
+#
 #     def checkall(self, before, after):
 #         # Because we need to check with and without the itertools prefix
 #         # and on each of the three functions, these loops make it all
@@ -3487,132 +3487,132 @@ class Test_print(FixerTestCase):
 #                 b = before %(i+'i'+f)
 #                 a = after %(f)
 #                 self.check(b, a)
-# 
+#
 #     def test_0(self):
 #         # A simple example -- test_1 covers exactly the same thing,
 #         # but it's not quite as clear.
 #         b = "itertools.izip(a, b)"
 #         a = "zip(a, b)"
 #         self.check(b, a)
-# 
+#
 #     def test_1(self):
 #         b = """%s(f, a)"""
 #         a = """%s(f, a)"""
 #         self.checkall(b, a)
-# 
+#
 #     def test_qualified(self):
 #         b = """itertools.ifilterfalse(a, b)"""
 #         a = """itertools.filterfalse(a, b)"""
 #         self.check(b, a)
-# 
+#
 #         b = """itertools.izip_longest(a, b)"""
 #         a = """itertools.zip_longest(a, b)"""
 #         self.check(b, a)
-# 
+#
 #     def test_2(self):
 #         b = """ifilterfalse(a, b)"""
 #         a = """filterfalse(a, b)"""
 #         self.check(b, a)
-# 
+#
 #         b = """izip_longest(a, b)"""
 #         a = """zip_longest(a, b)"""
 #         self.check(b, a)
-# 
+#
 #     def test_space_1(self):
 #         b = """    %s(f, a)"""
 #         a = """    %s(f, a)"""
 #         self.checkall(b, a)
-# 
+#
 #     def test_space_2(self):
 #         b = """    itertools.ifilterfalse(a, b)"""
 #         a = """    itertools.filterfalse(a, b)"""
 #         self.check(b, a)
-# 
+#
 #         b = """    itertools.izip_longest(a, b)"""
 #         a = """    itertools.zip_longest(a, b)"""
 #         self.check(b, a)
-# 
+#
 #     def test_run_order(self):
 #         self.assert_runs_after('map', 'zip', 'filter')
-# 
-# 
+#
+#
 # class Test_itertools_imports(FixerTestCase):
 #     fixer = 'itertools_imports'
-# 
+#
 #     def test_reduced(self):
 #         b = "from itertools import imap, izip, foo"
 #         a = "from itertools import foo"
 #         self.check(b, a)
-# 
+#
 #         b = "from itertools import bar, imap, izip, foo"
 #         a = "from itertools import bar, foo"
 #         self.check(b, a)
-# 
+#
 #         b = "from itertools import chain, imap, izip"
 #         a = "from itertools import chain"
 #         self.check(b, a)
-# 
+#
 #     def test_comments(self):
 #         b = "#foo\nfrom itertools import imap, izip"
 #         a = "#foo\n"
 #         self.check(b, a)
-# 
+#
 #     def test_none(self):
 #         b = "from itertools import imap, izip"
 #         a = ""
 #         self.check(b, a)
-# 
+#
 #         b = "from itertools import izip"
 #         a = ""
 #         self.check(b, a)
-# 
+#
 #     def test_import_as(self):
 #         b = "from itertools import izip, bar as bang, imap"
 #         a = "from itertools import bar as bang"
 #         self.check(b, a)
-# 
+#
 #         b = "from itertools import izip as _zip, imap, bar"
 #         a = "from itertools import bar"
 #         self.check(b, a)
-# 
+#
 #         b = "from itertools import imap as _map"
 #         a = ""
 #         self.check(b, a)
-# 
+#
 #         b = "from itertools import imap as _map, izip as _zip"
 #         a = ""
 #         self.check(b, a)
-# 
+#
 #         s = "from itertools import bar as bang"
 #         self.unchanged(s)
-# 
+#
 #     def test_ifilter_and_zip_longest(self):
 #         for name in "filterfalse", "zip_longest":
 #             b = "from itertools import i%s" % (name,)
 #             a = "from itertools import %s" % (name,)
 #             self.check(b, a)
-# 
+#
 #             b = "from itertools import imap, i%s, foo" % (name,)
 #             a = "from itertools import %s, foo" % (name,)
 #             self.check(b, a)
-# 
+#
 #             b = "from itertools import bar, i%s, foo" % (name,)
 #             a = "from itertools import bar, %s, foo" % (name,)
 #             self.check(b, a)
-# 
+#
 #     def test_import_star(self):
 #         s = "from itertools import *"
 #         self.unchanged(s)
-# 
-# 
+#
+#
 #     def test_unchanged(self):
 #         s = "from itertools import foo"
 #         self.unchanged(s)
-# 
-# 
+#
+#
 # class Test_import(FixerTestCase):
 #     fixer = "import"
-# 
+#
 #     def setUp(self):
 #         super(Test_import, self).setUp()
 #         # Need to replace fix_import's exists method
@@ -3623,145 +3623,145 @@ class Test_print(FixerTestCase):
 #         def fake_exists(name):
 #             self.files_checked.append(name)
 #             return self.always_exists or (name in self.present_files)
-# 
+#
 #         from lib2to3.fixes import fix_import
 #         fix_import.exists = fake_exists
-# 
+#
 #     def tearDown(self):
 #         from lib2to3.fixes import fix_import
 #         fix_import.exists = os.path.exists
-# 
+#
 #     def check_both(self, b, a):
 #         self.always_exists = True
 #         super(Test_import, self).check(b, a)
 #         self.always_exists = False
 #         super(Test_import, self).unchanged(b)
-# 
+#
 #     def test_files_checked(self):
 #         def p(path):
 #             # Takes a unix path and returns a path with correct separators
 #             return os.path.pathsep.join(path.split("/"))
-# 
+#
 #         self.always_exists = False
 #         self.present_files = set(['__init__.py'])
 #         expected_extensions = ('.py', os.path.sep, '.pyc', '.so', '.sl', '.pyd')
 #         names_to_test = (p("/spam/eggs.py"), "ni.py", p("../../shrubbery.py"))
-# 
+#
 #         for name in names_to_test:
 #             self.files_checked = []
 #             self.filename = name
 #             self.unchanged("import jam")
-# 
+#
 #             if os.path.dirname(name):
 #                 name = os.path.dirname(name) + '/jam'
 #             else:
 #                 name = 'jam'
 #             expected_checks = set(name + ext for ext in expected_extensions)
 #             expected_checks.add("__init__.py")
-# 
+#
 #             self.assertEqual(set(self.files_checked), expected_checks)
-# 
+#
 #     def test_not_in_package(self):
 #         s = "import bar"
 #         self.always_exists = False
 #         self.present_files = set(["bar.py"])
 #         self.unchanged(s)
-# 
+#
 #     def test_with_absolute_import_enabled(self):
 #         s = "from __future__ import absolute_import\nimport bar"
 #         self.always_exists = False
 #         self.present_files = set(["__init__.py", "bar.py"])
 #         self.unchanged(s)
-# 
+#
 #     def test_in_package(self):
 #         b = "import bar"
 #         a = "from . import bar"
 #         self.always_exists = False
 #         self.present_files = set(["__init__.py", "bar.py"])
 #         self.check(b, a)
-# 
+#
 #     def test_import_from_package(self):
 #         b = "import bar"
 #         a = "from . import bar"
 #         self.always_exists = False
 #         self.present_files = set(["__init__.py", "bar" + os.path.sep])
 #         self.check(b, a)
-# 
+#
 #     def test_already_relative_import(self):
 #         s = "from . import bar"
 #         self.unchanged(s)
-# 
+#
 #     def test_comments_and_indent(self):
 #         b = "import bar # Foo"
 #         a = "from . import bar # Foo"
 #         self.check(b, a)
-# 
+#
 #     def test_from(self):
 #         b = "from foo import bar, baz"
 #         a = "from .foo import bar, baz"
 #         self.check_both(b, a)
-# 
+#
 #         b = "from foo import bar"
 #         a = "from .foo import bar"
 #         self.check_both(b, a)
-# 
+#
 #         b = "from foo import (bar, baz)"
 #         a = "from .foo import (bar, baz)"
 #         self.check_both(b, a)
-# 
+#
 #     def test_dotted_from(self):
 #         b = "from green.eggs import ham"
 #         a = "from .green.eggs import ham"
 #         self.check_both(b, a)
-# 
+#
 #     def test_from_as(self):
 #         b = "from green.eggs import ham as spam"
 #         a = "from .green.eggs import ham as spam"
 #         self.check_both(b, a)
-# 
+#
 #     def test_import(self):
 #         b = "import foo"
 #         a = "from . import foo"
 #         self.check_both(b, a)
-# 
+#
 #         b = "import foo, bar"
 #         a = "from . import foo, bar"
 #         self.check_both(b, a)
-# 
+#
 #         b = "import foo, bar, x"
 #         a = "from . import foo, bar, x"
 #         self.check_both(b, a)
-# 
+#
 #         b = "import x, y, z"
 #         a = "from . import x, y, z"
 #         self.check_both(b, a)
-# 
+#
 #     def test_import_as(self):
 #         b = "import foo as x"
 #         a = "from . import foo as x"
 #         self.check_both(b, a)
-# 
+#
 #         b = "import a as b, b as c, c as d"
 #         a = "from . import a as b, b as c, c as d"
 #         self.check_both(b, a)
-# 
+#
 #     def test_local_and_absolute(self):
 #         self.always_exists = False
 #         self.present_files = set(["foo.py", "__init__.py"])
-# 
+#
 #         s = "import foo, bar"
 #         self.warns_unchanged(s, "absolute and local imports together")
-# 
+#
 #     def test_dotted_import(self):
 #         b = "import foo.bar"
 #         a = "from . import foo.bar"
 #         self.check_both(b, a)
-# 
+#
 #     def test_dotted_import_as(self):
 #         b = "import foo.bar as bang"
 #         a = "from . import foo.bar as bang"
 #         self.check_both(b, a)
-# 
+#
 #     def test_prefix(self):
 #         b = """
 #         # prefix
@@ -3772,101 +3772,101 @@ class Test_print(FixerTestCase):
 #         from . import foo.bar
 #         """
 #         self.check_both(b, a)
-# 
-# 
+#
+#
 # class Test_set_literal(FixerTestCase):
-# 
+#
 #     fixer = "set_literal"
-# 
+#
 #     def test_basic(self):
 #         b = """set([1, 2, 3])"""
 #         a = """{1, 2, 3}"""
 #         self.check(b, a)
-# 
+#
 #         b = """set((1, 2, 3))"""
 #         a = """{1, 2, 3}"""
 #         self.check(b, a)
-# 
+#
 #         b = """set((1,))"""
 #         a = """{1}"""
 #         self.check(b, a)
-# 
+#
 #         b = """set([1])"""
 #         self.check(b, a)
-# 
+#
 #         b = """set((a, b))"""
 #         a = """{a, b}"""
 #         self.check(b, a)
-# 
+#
 #         b = """set([a, b])"""
 #         self.check(b, a)
-# 
+#
 #         b = """set((a*234, f(args=23)))"""
 #         a = """{a*234, f(args=23)}"""
 #         self.check(b, a)
-# 
+#
 #         b = """set([a*23, f(23)])"""
 #         a = """{a*23, f(23)}"""
 #         self.check(b, a)
-# 
+#
 #         b = """set([a-234**23])"""
 #         a = """{a-234**23}"""
 #         self.check(b, a)
-# 
+#
 #     def test_listcomps(self):
 #         b = """set([x for x in y])"""
 #         a = """{x for x in y}"""
 #         self.check(b, a)
-# 
+#
 #         b = """set([x for x in y if x == m])"""
 #         a = """{x for x in y if x == m}"""
 #         self.check(b, a)
-# 
+#
 #         b = """set([x for x in y for a in b])"""
 #         a = """{x for x in y for a in b}"""
 #         self.check(b, a)
-# 
+#
 #         b = """set([f(x) - 23 for x in y])"""
 #         a = """{f(x) - 23 for x in y}"""
 #         self.check(b, a)
-# 
+#
 #     def test_whitespace(self):
 #         b = """set( [1, 2])"""
 #         a = """{1, 2}"""
 #         self.check(b, a)
-# 
+#
 #         b = """set([1 ,  2])"""
 #         a = """{1 ,  2}"""
 #         self.check(b, a)
-# 
+#
 #         b = """set([ 1 ])"""
 #         a = """{ 1 }"""
 #         self.check(b, a)
-# 
+#
 #         b = """set( [1] )"""
 #         a = """{1}"""
 #         self.check(b, a)
-# 
+#
 #         b = """set([  1,  2  ])"""
 #         a = """{  1,  2  }"""
 #         self.check(b, a)
-# 
+#
 #         b = """set([x  for x in y ])"""
 #         a = """{x  for x in y }"""
 #         self.check(b, a)
-# 
+#
 #         b = """set(
 #                    [1, 2]
 #                )
 #             """
 #         a = """{1, 2}\n"""
 #         self.check(b, a)
-# 
+#
 #     def test_comments(self):
 #         b = """set((1, 2)) # Hi"""
 #         a = """{1, 2} # Hi"""
 #         self.check(b, a)
-# 
+#
 #         # This isn't optimal behavior, but the fixer is optional.
 #         b = """
 #             # Foo
@@ -3879,124 +3879,124 @@ class Test_print(FixerTestCase):
 #             {1, 2}
 #             """
 #         self.check(b, a)
-# 
+#
 #     def test_unchanged(self):
 #         s = """set()"""
 #         self.unchanged(s)
-# 
+#
 #         s = """set(a)"""
 #         self.unchanged(s)
-# 
+#
 #         s = """set(a, b, c)"""
 #         self.unchanged(s)
-# 
+#
 #         # Don't transform generators because they might have to be lazy.
 #         s = """set(x for x in y)"""
 #         self.unchanged(s)
-# 
+#
 #         s = """set(x for x in y if z)"""
 #         self.unchanged(s)
-# 
+#
 #         s = """set(a*823-23**2 + f(23))"""
 #         self.unchanged(s)
-# 
-# 
+#
+#
 # class Test_sys_exc(FixerTestCase):
 #     fixer = "sys_exc"
-# 
+#
 #     def test_0(self):
 #         b = "sys.exc_type"
 #         a = "sys.exc_info()[0]"
 #         self.check(b, a)
-# 
+#
 #     def test_1(self):
 #         b = "sys.exc_value"
 #         a = "sys.exc_info()[1]"
 #         self.check(b, a)
-# 
+#
 #     def test_2(self):
 #         b = "sys.exc_traceback"
 #         a = "sys.exc_info()[2]"
 #         self.check(b, a)
-# 
+#
 #     def test_3(self):
 #         b = "sys.exc_type # Foo"
 #         a = "sys.exc_info()[0] # Foo"
 #         self.check(b, a)
-# 
+#
 #     def test_4(self):
 #         b = "sys.  exc_type"
 #         a = "sys.  exc_info()[0]"
 #         self.check(b, a)
-# 
+#
 #     def test_5(self):
 #         b = "sys  .exc_type"
 #         a = "sys  .exc_info()[0]"
 #         self.check(b, a)
-# 
-# 
+#
+#
 # class Test_paren(FixerTestCase):
 #     fixer = "paren"
-# 
+#
 #     def test_0(self):
 #         b = """[i for i in 1, 2 ]"""
 #         a = """[i for i in (1, 2) ]"""
 #         self.check(b, a)
-# 
+#
 #     def test_1(self):
 #         b = """[i for i in 1, 2, ]"""
 #         a = """[i for i in (1, 2,) ]"""
 #         self.check(b, a)
-# 
+#
 #     def test_2(self):
 #         b = """[i for i  in     1, 2 ]"""
 #         a = """[i for i  in     (1, 2) ]"""
 #         self.check(b, a)
-# 
+#
 #     def test_3(self):
 #         b = """[i for i in 1, 2 if i]"""
 #         a = """[i for i in (1, 2) if i]"""
 #         self.check(b, a)
-# 
+#
 #     def test_4(self):
 #         b = """[i for i in 1,    2    ]"""
 #         a = """[i for i in (1,    2)    ]"""
 #         self.check(b, a)
-# 
+#
 #     def test_5(self):
 #         b = """(i for i in 1, 2)"""
 #         a = """(i for i in (1, 2))"""
 #         self.check(b, a)
-# 
+#
 #     def test_6(self):
 #         b = """(i for i in 1   ,2   if i)"""
 #         a = """(i for i in (1   ,2)   if i)"""
 #         self.check(b, a)
-# 
+#
 #     def test_unchanged_0(self):
 #         s = """[i for i in (1, 2)]"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_1(self):
 #         s = """[i for i in foo()]"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_2(self):
 #         s = """[i for i in (1, 2) if nothing]"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_3(self):
 #         s = """(i for i in (1, 2))"""
 #         self.unchanged(s)
-# 
+#
 #     def test_unchanged_4(self):
 #         s = """[i for i in m]"""
 #         self.unchanged(s)
-# 
+#
 # class Test_metaclass(FixerTestCase):
-# 
+#
 #     fixer = 'metaclass'
-# 
+#
 #     def test_unchanged(self):
 #         self.unchanged("class X(): pass")
 #         self.unchanged("class X(object): pass")
@@ -4005,19 +4005,19 @@ class Test_print(FixerTestCase):
 #         self.unchanged("class X(metaclass=Meta): pass")
 #         self.unchanged("class X(b, arg=23, metclass=Meta): pass")
 #         self.unchanged("class X(b, arg=23, metaclass=Meta, other=42): pass")
-# 
+#
 #         s = """
 #         class X:
 #             def __metaclass__(self): pass
 #         """
 #         self.unchanged(s)
-# 
+#
 #         s = """
 #         class X:
 #             a[23] = 74
 #         """
 #         self.unchanged(s)
-# 
+#
 #     def test_comments(self):
 #         b = """
 #         class X:
@@ -4030,7 +4030,7 @@ class Test_print(FixerTestCase):
 #             pass
 #         """
 #         self.check(b, a)
-# 
+#
 #         b = """
 #         class X:
 #             __metaclass__ = Meta
@@ -4042,7 +4042,7 @@ class Test_print(FixerTestCase):
 #             # Bedtime!
 #         """
 #         self.check(b, a)
-# 
+#
 #     def test_meta(self):
 #         # no-parent class, odd body
 #         b = """
@@ -4055,13 +4055,13 @@ class Test_print(FixerTestCase):
 #             pass
 #         """
 #         self.check(b, a)
-# 
+#
 #         # one parent class, no body
 #         b = """class X(object): __metaclass__ = Q"""
 #         a = """class X(object, metaclass=Q): pass"""
 #         self.check(b, a)
-# 
-# 
+#
+#
 #         # one parent, simple body
 #         b = """
 #         class X(object):
@@ -4073,7 +4073,7 @@ class Test_print(FixerTestCase):
 #             bar = 7
 #         """
 #         self.check(b, a)
-# 
+#
 #         b = """
 #         class X:
 #             __metaclass__ = Meta; x = 4; g = 23
@@ -4083,7 +4083,7 @@ class Test_print(FixerTestCase):
 #             x = 4; g = 23
 #         """
 #         self.check(b, a)
-# 
+#
 #         # one parent, simple body, __metaclass__ last
 #         b = """
 #         class X(object):
@@ -4095,7 +4095,7 @@ class Test_print(FixerTestCase):
 #             bar = 7
 #         """
 #         self.check(b, a)
-# 
+#
 #         # redefining __metaclass__
 #         b = """
 #         class X():
@@ -4108,7 +4108,7 @@ class Test_print(FixerTestCase):
 #             bar = 7
 #         """
 #         self.check(b, a)
-# 
+#
 #         # multiple inheritance, simple body
 #         b = """
 #         class X(clsA, clsB):
@@ -4120,12 +4120,12 @@ class Test_print(FixerTestCase):
 #             bar = 7
 #         """
 #         self.check(b, a)
-# 
+#
 #         # keywords in the class statement
 #         b = """class m(a, arg=23): __metaclass__ = Meta"""
 #         a = """class m(a, arg=23, metaclass=Meta): pass"""
 #         self.check(b, a)
-# 
+#
 #         b = """
 #         class X(expression(2 + 4)):
 #             __metaclass__ = Meta
@@ -4135,7 +4135,7 @@ class Test_print(FixerTestCase):
 #             pass
 #         """
 #         self.check(b, a)
-# 
+#
 #         b = """
 #         class X(expression(2 + 4), x**4):
 #             __metaclass__ = Meta
@@ -4145,7 +4145,7 @@ class Test_print(FixerTestCase):
 #             pass
 #         """
 #         self.check(b, a)
-# 
+#
 #         b = """
 #         class X:
 #             __metaclass__ = Meta
@@ -4156,44 +4156,44 @@ class Test_print(FixerTestCase):
 #             save.py = 23
 #         """
 #         self.check(b, a)
-# 
-# 
+#
+#
 # class Test_getcwdu(FixerTestCase):
-# 
+#
 #     fixer = 'getcwdu'
-# 
+#
 #     def test_basic(self):
 #         b = """os.getcwdu"""
 #         a = """os.getcwd"""
 #         self.check(b, a)
-# 
+#
 #         b = """os.getcwdu()"""
 #         a = """os.getcwd()"""
 #         self.check(b, a)
-# 
+#
 #         b = """meth = os.getcwdu"""
 #         a = """meth = os.getcwd"""
 #         self.check(b, a)
-# 
+#
 #         b = """os.getcwdu(args)"""
 #         a = """os.getcwd(args)"""
 #         self.check(b, a)
-# 
+#
 #     def test_comment(self):
 #         b = """os.getcwdu() # Foo"""
 #         a = """os.getcwd() # Foo"""
 #         self.check(b, a)
-# 
+#
 #     def test_unchanged(self):
 #         s = """os.getcwd()"""
 #         self.unchanged(s)
-# 
+#
 #         s = """getcwdu()"""
 #         self.unchanged(s)
-# 
+#
 #         s = """os.getcwdb()"""
 #         self.unchanged(s)
-# 
+#
 #     def test_indentation(self):
 #         b = """
 #             if 1:
@@ -4204,124 +4204,124 @@ class Test_print(FixerTestCase):
 #                 os.getcwd()
 #             """
 #         self.check(b, a)
-# 
+#
 #     def test_multilation(self):
 #         b = """os .getcwdu()"""
 #         a = """os .getcwd()"""
 #         self.check(b, a)
-# 
+#
 #         b = """os.  getcwdu"""
 #         a = """os.  getcwd"""
 #         self.check(b, a)
-# 
+#
 #         b = """os.getcwdu (  )"""
 #         a = """os.getcwd (  )"""
 #         self.check(b, a)
-# 
-# 
+#
+#
 # class Test_operator(FixerTestCase):
-# 
+#
 #     fixer = "operator"
-# 
+#
 #     def test_operator_isCallable(self):
 #         b = "operator.isCallable(x)"
 #         a = "hasattr(x, '__call__')"
 #         self.check(b, a)
-# 
+#
 #     def test_operator_sequenceIncludes(self):
 #         b = "operator.sequenceIncludes(x, y)"
 #         a = "operator.contains(x, y)"
 #         self.check(b, a)
-# 
+#
 #         b = "operator .sequenceIncludes(x, y)"
 #         a = "operator .contains(x, y)"
 #         self.check(b, a)
-# 
+#
 #         b = "operator.  sequenceIncludes(x, y)"
 #         a = "operator.  contains(x, y)"
 #         self.check(b, a)
-# 
+#
 #     def test_operator_isSequenceType(self):
 #         b = "operator.isSequenceType(x)"
 #         a = "import collections\nisinstance(x, collections.Sequence)"
 #         self.check(b, a)
-# 
+#
 #     def test_operator_isMappingType(self):
 #         b = "operator.isMappingType(x)"
 #         a = "import collections\nisinstance(x, collections.Mapping)"
 #         self.check(b, a)
-# 
+#
 #     def test_operator_isNumberType(self):
 #         b = "operator.isNumberType(x)"
 #         a = "import numbers\nisinstance(x, numbers.Number)"
 #         self.check(b, a)
-# 
+#
 #     def test_operator_repeat(self):
 #         b = "operator.repeat(x, n)"
 #         a = "operator.mul(x, n)"
 #         self.check(b, a)
-# 
+#
 #         b = "operator .repeat(x, n)"
 #         a = "operator .mul(x, n)"
 #         self.check(b, a)
-# 
+#
 #         b = "operator.  repeat(x, n)"
 #         a = "operator.  mul(x, n)"
 #         self.check(b, a)
-# 
+#
 #     def test_operator_irepeat(self):
 #         b = "operator.irepeat(x, n)"
 #         a = "operator.imul(x, n)"
 #         self.check(b, a)
-# 
+#
 #         b = "operator .irepeat(x, n)"
 #         a = "operator .imul(x, n)"
 #         self.check(b, a)
-# 
+#
 #         b = "operator.  irepeat(x, n)"
 #         a = "operator.  imul(x, n)"
 #         self.check(b, a)
-# 
+#
 #     def test_bare_isCallable(self):
 #         s = "isCallable(x)"
 #         t = "You should use 'hasattr(x, '__call__')' here."
 #         self.warns_unchanged(s, t)
-# 
+#
 #     def test_bare_sequenceIncludes(self):
 #         s = "sequenceIncludes(x, y)"
 #         t = "You should use 'operator.contains(x, y)' here."
 #         self.warns_unchanged(s, t)
-# 
+#
 #     def test_bare_operator_isSequenceType(self):
 #         s = "isSequenceType(z)"
 #         t = "You should use 'isinstance(z, collections.Sequence)' here."
 #         self.warns_unchanged(s, t)
-# 
+#
 #     def test_bare_operator_isMappingType(self):
 #         s = "isMappingType(x)"
 #         t = "You should use 'isinstance(x, collections.Mapping)' here."
 #         self.warns_unchanged(s, t)
-# 
+#
 #     def test_bare_operator_isNumberType(self):
 #         s = "isNumberType(y)"
 #         t = "You should use 'isinstance(y, numbers.Number)' here."
 #         self.warns_unchanged(s, t)
-# 
+#
 #     def test_bare_operator_repeat(self):
 #         s = "repeat(x, n)"
 #         t = "You should use 'operator.mul(x, n)' here."
 #         self.warns_unchanged(s, t)
-# 
+#
 #     def test_bare_operator_irepeat(self):
 #         s = "irepeat(y, 187)"
 #         t = "You should use 'operator.imul(y, 187)' here."
 #         self.warns_unchanged(s, t)
-# 
-# 
+#
+#
 # class Test_exitfunc(FixerTestCase):
-# 
+#
 #     fixer = "exitfunc"
-# 
+#
 #     def test_simple(self):
 #         b = """
 #             import sys
@@ -4333,7 +4333,7 @@ class Test_print(FixerTestCase):
 #             atexit.register(my_atexit)
 #             """
 #         self.check(b, a)
-# 
+#
 #     def test_names_import(self):
 #         b = """
 #             import sys, crumbs
@@ -4344,7 +4344,7 @@ class Test_print(FixerTestCase):
 #             atexit.register(my_func)
 #             """
 #         self.check(b, a)
-# 
+#
 #     def test_complex_expression(self):
 #         b = """
 #             import sys
@@ -4356,7 +4356,7 @@ class Test_print(FixerTestCase):
 #             atexit.register(do(d)/a()+complex(f=23, g=23)*expression)
 #             """
 #         self.check(b, a)
-# 
+#
 #     def test_comments(self):
 #         b = """
 #             import sys # Foo
@@ -4368,7 +4368,7 @@ class Test_print(FixerTestCase):
 #             atexit.register(f) # Blah
 #             """
 #         self.check(b, a)
-# 
+#
 #         b = """
 #             import apples, sys, crumbs, larry # Pleasant comments
 #             sys.exitfunc = func
@@ -4378,7 +4378,7 @@ class Test_print(FixerTestCase):
 #             atexit.register(func)
 #             """
 #         self.check(b, a)
-# 
+#
 #     def test_in_a_function(self):
 #         b = """
 #             import sys
@@ -4392,15 +4392,15 @@ class Test_print(FixerTestCase):
 #                 atexit.register(func)
 #              """
 #         self.check(b, a)
-# 
+#
 #     def test_no_sys_import(self):
 #         b = """sys.exitfunc = f"""
 #         a = """atexit.register(f)"""
 #         msg = ("Can't find sys import; Please add an atexit import at the "
 #             "top of your file.")
 #         self.warns(b, a, msg)
-# 
-# 
+#
+#
 #     def test_unchanged(self):
 #         s = """f(sys.exitfunc)"""
 #         self.unchanged(s)

--- a/tests/test_future/test_magicsuper.py
+++ b/tests/test_future/test_magicsuper.py
@@ -133,4 +133,3 @@ class TestMagicSuper(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/test_future/test_object.py
+++ b/tests/test_future/test_object.py
@@ -39,7 +39,7 @@ class TestNewObject(unittest.TestCase):
             assert str(a) == str(b)
 
     def test_implements_py2_iterator(self):
-        
+
         class Upper(object):
             def __init__(self, iterable):
                 self._iter = iter(iterable)
@@ -57,7 +57,7 @@ class TestNewObject(unittest.TestCase):
                 return 'Next!'
             def __iter__(self):
                 return self
-        
+
         itr = MyIter()
         self.assertEqual(next(itr), 'Next!')
 
@@ -68,7 +68,7 @@ class TestNewObject(unittest.TestCase):
             self.assertEqual(item, 'Next!')
 
     def test_implements_py2_nonzero(self):
-        
+
         class EvenIsTrue(object):
             """
             An integer that evaluates to True if even.
@@ -94,7 +94,7 @@ class TestNewObject(unittest.TestCase):
         maps to __bool__ in case the user redefines __bool__ in a subclass of
         newint.
         """
-        
+
         class EvenIsTrue(int):
             """
             An integer that evaluates to True if even.
@@ -137,7 +137,7 @@ class TestNewObject(unittest.TestCase):
 
     def test_isinstance_object_subclass(self):
         """
-        This was failing before 
+        This was failing before
         """
         class A(object):
             pass

--- a/tests/test_future/test_pasteurize.py
+++ b/tests/test_future/test_pasteurize.py
@@ -96,7 +96,7 @@ class TestPasteurize(CodeHandler):
     def test_urllib_request(self):
         """
         Example Python 3 code using the new urllib.request module.
-        
+
         Does the ``pasteurize`` script handle this?
         """
         before = """
@@ -105,7 +105,7 @@ class TestPasteurize(CodeHandler):
 
             URL = 'http://pypi.python.org/pypi/{}/json'
             package = 'future'
-            
+
             r = urllib.request.urlopen(URL.format(package))
             pprint.pprint(r.read())
         """
@@ -115,7 +115,7 @@ class TestPasteurize(CodeHandler):
 
             URL = 'http://pypi.python.org/pypi/{}/json'
             package = 'future'
-            
+
             r = urllib_request.urlopen(URL.format(package))
             pprint.pprint(r.read())
         """
@@ -150,7 +150,7 @@ class TestPasteurize(CodeHandler):
         retcode = main([self.textfilename])
         self.assertTrue(isinstance(retcode, int))   # i.e. Py2 builtin int
 
- 
+
 class TestFuturizeAnnotations(CodeHandler):
     @unittest.expectedFailure
     def test_return_annotations_alone(self):
@@ -250,7 +250,7 @@ class TestFuturizeAnnotations(CodeHandler):
             pass
         """
         self.unchanged(s, from3=True)
-        
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_future/test_standard_library.py
+++ b/tests/test_future/test_standard_library.py
@@ -30,7 +30,7 @@ class TestStandardLibraryReorganization(CodeHandler):
         """
         This test failed in v0.12-pre if e.g.
         future/standard_library/email/header.py contained:
-        
+
             from future import standard_library
             standard_library.remove_hooks()
         """
@@ -274,7 +274,7 @@ class TestStandardLibraryReorganization(CodeHandler):
     # Disabled since v0.16.0:
     # def test_configparser(self):
     #     import configparser
-    
+
     def test_copyreg(self):
         import copyreg
 
@@ -283,7 +283,7 @@ class TestStandardLibraryReorganization(CodeHandler):
 
     def test_profile(self):
         import profile
-    
+
     def test_stringio(self):
         from io import StringIO
         s = StringIO(u'test')

--- a/tests/test_future/test_str.py
+++ b/tests/test_future/test_str.py
@@ -258,7 +258,7 @@ class TestStr(unittest.TestCase):
         if utils.PY2:
             self.assertTrue(b'A' in s)
         with self.assertRaises(TypeError):
-            bytes(b'A') in s                  
+            bytes(b'A') in s
         with self.assertRaises(TypeError):
             65 in s                                 # unlike bytes
 

--- a/tests/test_past/test_builtins.py
+++ b/tests/test_past/test_builtins.py
@@ -1768,12 +1768,12 @@ class TestSorted(unittest.TestCase):
 #     #         ("classic int division", DeprecationWarning)):
 #     if True:
 #         run_unittest(*args)
-# 
+#
 # def test_main(verbose=None):
 #     test_classes = (BuiltinTest, TestSorted)
-# 
+#
 #     _run_unittest(*test_classes)
-# 
+#
 #     # verify reference counting
 #     if verbose and hasattr(sys, "gettotalrefcount"):
 #         import gc

--- a/tests/test_past/test_olddict.py
+++ b/tests/test_past/test_olddict.py
@@ -622,7 +622,7 @@ class Py2DictTest(unittest.TestCase):
     #                  'd.update({x2: 2})']:
     #         with self.assertRaises(CustomException):
     #             utils.exec_(stmt, locals())
-    # 
+    #
     # def test_resize1(self):
     #     # Dict resizing bug, found by Jack Jansen in 2.2 CVS development.
     #     # This version got an assert failure in debug build, infinite loop in

--- a/tests/test_past/test_translation.py
+++ b/tests/test_past/test_translation.py
@@ -67,7 +67,7 @@ class TestTranslate(unittest.TestCase):
             # print('Hooks removed')
             sys.path.remove(self.tempdir)
         return module
- 
+
     def test_print_statement(self):
         code = """
             print 'Hello from a Python 2-style print statement!'
@@ -82,7 +82,7 @@ class TestTranslate(unittest.TestCase):
         """
         module = self.write_and_import(code, 'execer')
         self.assertEqual(module.x, 7)
-        
+
     def test_div(self):
         code = """
         x = 3 / 2
@@ -173,14 +173,14 @@ class TestTranslate(unittest.TestCase):
         module = self.write_and_import(code, 'py2_exceptions')
         self.assertEqual(module.value, 'string: success!')
 
- 
+
 # class TestFuturizeSimple(CodeHandler):
 #     """
 #     This class contains snippets of Python 2 code (invalid Python 3) and
 #     tests for whether they can be imported correctly from Python 3 with the
 #     import hooks.
 #     """
-# 
+#
 #     @unittest.expectedFailure
 #     def test_problematic_string(self):
 #         """ This string generates a SyntaxError on Python 3 unless it has
@@ -193,7 +193,7 @@ class TestTranslate(unittest.TestCase):
 #         s = r'The folder is "C:\Users"'.
 #         """
 #         self.convert_check(before, after)
-# 
+#
 #     def test_tobytes(self):
 #         """
 #         The --tobytes option converts all UNADORNED string literals 'abcd' to b'abcd'.
@@ -228,7 +228,7 @@ class TestTranslate(unittest.TestCase):
 #         s8 = b"pqrs"
 #         """
 #         self.convert_check(before, after, tobytes=True)
-# 
+#
 #     @unittest.expectedFailure
 #     def test_izip(self):
 #         before = """
@@ -243,7 +243,7 @@ class TestTranslate(unittest.TestCase):
 #             pass
 #         """
 #         self.convert_check(before, after, stages=(1, 2), ignore_imports=False)
-# 
+#
 #     @unittest.expectedFailure
 #     def test_no_unneeded_list_calls(self):
 #         """
@@ -254,14 +254,14 @@ class TestTranslate(unittest.TestCase):
 #             pass
 #         """
 #         self.unchanged(code)
-# 
+#
 #     def test_xrange(self):
 #         code = '''
 #         for i in xrange(10):
 #             pass
 #         '''
 #         self.convert(code)
-#     
+#
 #     @unittest.expectedFailure
 #     def test_source_coding_utf8(self):
 #         """
@@ -275,7 +275,7 @@ class TestTranslate(unittest.TestCase):
 #         icons = [u"◐", u"◓", u"◑", u"◒"]
 #         """
 #         self.unchanged(code)
-# 
+#
 #     def test_exception_syntax(self):
 #         """
 #         Test of whether futurize handles the old-style exception syntax
@@ -293,7 +293,7 @@ class TestTranslate(unittest.TestCase):
 #             val = e.errno
 #         """
 #         self.convert_check(before, after)
-# 
+#
 #     def test_super(self):
 #         """
 #         This tests whether futurize keeps the old two-argument super() calls the
@@ -306,7 +306,7 @@ class TestTranslate(unittest.TestCase):
 #                 super(VerboseList, self).append(item)
 #         '''
 #         self.unchanged(code)
-# 
+#
 #     @unittest.expectedFailure
 #     def test_file(self):
 #         """
@@ -323,41 +323,41 @@ class TestTranslate(unittest.TestCase):
 #         f.close()
 #         '''
 #         self.convert_check(before, after)
-# 
+#
 #     def test_apply(self):
 #         before = '''
 #         def addup(*x):
 #             return sum(x)
-#         
+#
 #         assert apply(addup, (10,20)) == 30
 #         '''
 #         after = """
 #         def addup(*x):
 #             return sum(x)
-#         
+#
 #         assert addup(*(10,20)) == 30
 #         """
 #         self.convert_check(before, after)
-#     
+#
 #     @unittest.skip('not implemented yet')
 #     def test_download_pypi_package_and_test(self, package_name='future'):
 #         URL = 'http://pypi.python.org/pypi/{0}/json'
-#         
+#
 #         import requests
 #         r = requests.get(URL.format(package_name))
 #         pprint.pprint(r.json())
-#         
+#
 #         download_url = r.json()['urls'][0]['url']
 #         filename = r.json()['urls'][0]['filename']
 #         # r2 = requests.get(download_url)
 #         # with open('/tmp/' + filename, 'w') as tarball:
 #         #     tarball.write(r2.content)
-# 
+#
 #     def test_raw_input(self):
 #         """
 #         Passes in a string to the waiting input() after futurize
 #         conversion.
-# 
+#
 #         The code is the first snippet from these docs:
 #             http://docs.python.org/2/library/2to3.html
 #         """
@@ -376,13 +376,13 @@ class TestTranslate(unittest.TestCase):
 #         greet(name)
 #         """
 #         self.convert_check(before, desired, run=False)
-# 
+#
 #         for interpreter in self.interpreters:
 #             p1 = Popen([interpreter, self.tempdir + 'mytestscript.py'],
 #                        stdout=PIPE, stdin=PIPE, stderr=PIPE)
 #             (stdout, stderr) = p1.communicate(b'Ed')
 #             self.assertEqual(stdout, b"What's your name?\nHello, Ed!\n")
-# 
+#
 #     def test_literal_prefixes_are_not_stripped(self):
 #         """
 #         Tests to ensure that the u'' and b'' prefixes on unicode strings and
@@ -397,7 +397,7 @@ class TestTranslate(unittest.TestCase):
 #         b = b'byte string'
 #         '''
 #         self.unchanged(code)
-# 
+#
 #     @unittest.expectedFailure
 #     def test_division(self):
 #         """
@@ -411,8 +411,8 @@ class TestTranslate(unittest.TestCase):
 #         x = old_div(1, 2)
 #         """
 #         self.convert_check(before, after, stages=[1])
-# 
-# 
+#
+#
 # class TestFuturizeRenamedStdlib(CodeHandler):
 #     def test_renamed_modules(self):
 #         before = """
@@ -420,7 +420,7 @@ class TestTranslate(unittest.TestCase):
 #         import copy_reg
 #         import cPickle
 #         import cStringIO
-# 
+#
 #         s = cStringIO.StringIO('blah')
 #         """
 #         after = """
@@ -428,18 +428,18 @@ class TestTranslate(unittest.TestCase):
 #         import copyreg
 #         import pickle
 #         import io
-# 
+#
 #         s = io.StringIO('blah')
 #         """
 #         self.convert_check(before, after)
-#     
+#
 #     @unittest.expectedFailure
 #     def test_urllib_refactor(self):
 #         # Code like this using urllib is refactored by futurize --stage2 to use
 #         # the new Py3 module names, but ``future`` doesn't support urllib yet.
 #         before = """
 #         import urllib
-# 
+#
 #         URL = 'http://pypi.python.org/pypi/future/json'
 #         package_name = 'future'
 #         r = urllib.urlopen(URL.format(package_name))
@@ -447,14 +447,14 @@ class TestTranslate(unittest.TestCase):
 #         """
 #         after = """
 #         import urllib.request
-#         
+#
 #         URL = 'http://pypi.python.org/pypi/future/json'
 #         package_name = 'future'
 #         r = urllib.request.urlopen(URL.format(package_name))
 #         data = r.read()
 #         """
 #         self.convert_check(before, after)
-# 
+#
 #     def test_renamed_copy_reg_and_cPickle_modules(self):
 #         """
 #         Example from docs.python.org/2/library/copy_reg.html
@@ -466,11 +466,11 @@ class TestTranslate(unittest.TestCase):
 #         class C(object):
 #             def __init__(self, a):
 #                 self.a = a
-# 
+#
 #         def pickle_c(c):
 #             print('pickling a C instance...')
 #             return C, (c.a,)
-# 
+#
 #         copy_reg.pickle(C, pickle_c)
 #         c = C(1)
 #         d = copy.copy(c)
@@ -483,23 +483,23 @@ class TestTranslate(unittest.TestCase):
 #         class C(object):
 #             def __init__(self, a):
 #                 self.a = a
-# 
+#
 #         def pickle_c(c):
 #             print('pickling a C instance...')
 #             return C, (c.a,)
-# 
+#
 #         copyreg.pickle(C, pickle_c)
 #         c = C(1)
 #         d = copy.copy(c)
 #         p = pickle.dumps(c)
 #         """
 #         self.convert_check(before, after)
-# 
+#
 #     @unittest.expectedFailure
 #     def test_Py2_StringIO_module(self):
 #         """
 #         Ideally, there would be a fixer for this. For now:
-# 
+#
 #         TODO: add the Py3 equivalent for this to the docs
 #         """
 #         before = """
@@ -515,19 +515,19 @@ class TestTranslate(unittest.TestCase):
 #         # instead?
 #         """
 #         self.convert_check(before, after)
-# 
-# 
+#
+#
 # class TestFuturizeStage1(CodeHandler):
 #     # """
 #     # Tests "stage 1": safe optimizations: modernizing Python 2 code so that it
 #     # uses print functions, new-style exception syntax, etc.
-# 
+#
 #     # The behaviour should not change and this should introduce no dependency on
 #     # the ``future`` package. It produces more modern Python 2-only code. The
 #     # goal is to reduce the size of the real porting patch-set by performing
 #     # the uncontroversial patches first.
 #     # """
-# 
+#
 #     def test_apply(self):
 #         """
 #         apply() should be changed by futurize --stage1
@@ -535,7 +535,7 @@ class TestTranslate(unittest.TestCase):
 #         before = '''
 #         def f(a, b):
 #             return a + b
-# 
+#
 #         args = (1, 2)
 #         assert apply(f, args) == 3
 #         assert apply(f, ('a', 'b')) == 'ab'
@@ -543,13 +543,13 @@ class TestTranslate(unittest.TestCase):
 #         after = '''
 #         def f(a, b):
 #             return a + b
-# 
+#
 #         args = (1, 2)
 #         assert f(*args) == 3
 #         assert f(*('a', 'b')) == 'ab'
 #         '''
 #         self.convert_check(before, after, stages=[1])
-# 
+#
 #     def test_xrange(self):
 #         """
 #         xrange should not be changed by futurize --stage1
@@ -559,18 +559,18 @@ class TestTranslate(unittest.TestCase):
 #             pass
 #         '''
 #         self.unchanged(code, stages=[1])
-# 
+#
 #     @unittest.expectedFailure
 #     def test_absolute_import_changes(self):
 #         """
 #         Implicit relative imports should be converted to absolute or explicit
 #         relative imports correctly.
-# 
+#
 #         Issue #16 (with porting bokeh/bbmodel.py)
 #         """
 #         with open('specialmodels.py', 'w') as f:
 #             f.write('pass')
-# 
+#
 #         before = """
 #         import specialmodels.pandasmodel
 #         specialmodels.pandasmodel.blah()
@@ -581,7 +581,7 @@ class TestTranslate(unittest.TestCase):
 #         pandasmodel.blah()
 #         """
 #         self.convert_check(before, after, stages=[1])
-# 
+#
 #     def test_safe_futurize_imports(self):
 #         """
 #         The standard library module names should not be changed until stage 2
@@ -590,13 +590,13 @@ class TestTranslate(unittest.TestCase):
 #         import ConfigParser
 #         import HTMLParser
 #         import collections
-# 
+#
 #         ConfigParser.ConfigParser
 #         HTMLParser.HTMLParser
 #         d = collections.OrderedDict()
 #         """
 #         self.unchanged(before, stages=[1])
-# 
+#
 #     def test_print(self):
 #         before = """
 #         print 'Hello'
@@ -605,7 +605,7 @@ class TestTranslate(unittest.TestCase):
 #         print('Hello')
 #         """
 #         self.convert_check(before, after, stages=[1])
-# 
+#
 #         before = """
 #         import sys
 #         print >> sys.stderr, 'Hello', 'world'
@@ -615,16 +615,16 @@ class TestTranslate(unittest.TestCase):
 #         print('Hello', 'world', file=sys.stderr)
 #         """
 #         self.convert_check(before, after, stages=[1])
-# 
+#
 #     def test_print_already_function(self):
 #         """
-#         Running futurize --stage1 should not add a second set of parentheses 
+#         Running futurize --stage1 should not add a second set of parentheses
 #         """
 #         before = """
 #         print('Hello')
 #         """
 #         self.unchanged(before, stages=[1])
-# 
+#
 #     @unittest.expectedFailure
 #     def test_print_already_function_complex(self):
 #         """
@@ -639,7 +639,7 @@ class TestTranslate(unittest.TestCase):
 #         print('Hello', 'world', file=sys.stderr)
 #         """
 #         self.unchanged(before, stages=[1])
-# 
+#
 #     def test_exceptions(self):
 #         before = """
 #         try:
@@ -654,7 +654,7 @@ class TestTranslate(unittest.TestCase):
 #             pass
 #         """
 #         self.convert_check(before, after, stages=[1])
-# 
+#
 #     @unittest.expectedFailure
 #     def test_string_exceptions(self):
 #         """
@@ -674,7 +674,7 @@ class TestTranslate(unittest.TestCase):
 #             pass
 #         """
 #         self.convert_check(before, after, stages=[1])
-# 
+#
 #     @unittest.expectedFailure
 #     def test_oldstyle_classes(self):
 #         """
@@ -689,8 +689,8 @@ class TestTranslate(unittest.TestCase):
 #             pass
 #         """
 #         self.convert_check(before, after, stages=[1])
-# 
-#         
+#
+#
 #     def test_octal_literals(self):
 #         before = """
 #         mode = 0644
@@ -699,7 +699,7 @@ class TestTranslate(unittest.TestCase):
 #         mode = 0o644
 #         """
 #         self.convert_check(before, after)
-# 
+#
 #     def test_long_int_literals(self):
 #         before = """
 #         bignumber = 12345678901234567890L
@@ -708,7 +708,7 @@ class TestTranslate(unittest.TestCase):
 #         bignumber = 12345678901234567890
 #         """
 #         self.convert_check(before, after)
-# 
+#
 #     def test___future___import_position(self):
 #         """
 #         Issue #4: __future__ imports inserted too low in file: SyntaxError
@@ -722,13 +722,13 @@ class TestTranslate(unittest.TestCase):
 #         #
 #         # another comment
 #         #
-#         
+#
 #         CONSTANTS = [ 0, 01, 011, 0111, 012, 02, 021, 0211, 02111, 013 ]
 #         _RN_LETTERS = "IVXLCDM"
-#         
+#
 #         def my_func(value):
 #             pass
-#         
+#
 #         ''' Docstring-like comment here '''
 #         """
 #         self.convert(code)
@@ -736,4 +736,3 @@ class TestTranslate(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all in one go, it helps keep future diffs cleaner by avoiding spurious white space changes on unrelated lines.