### PR TITLE
Travis CI: Run flake8 tests to find syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,23 @@
+sudo: false
 language: python
 cache: pip
 python:
   - "3.6"
   - "3.5"
   - "3.4"
-  - "3.3"
   - "2.7"
-  - "2.6"
-
-sudo: false
-
-# command to install dependencies, e.g. pip install -r requirements.txt
-# These packages only exist on Ubuntu 13.04 and newer:
-# No dependencies currently unless using Python 2.6.
 
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.6* ]]; then pip install -r requirements_py26.txt; fi
   - python setup.py install
+
+before_script:
+  # 1) stop the build if there are Python syntax errors or undefined names
+  # 2) exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then
+      pip install flake8;
+      flake8 . --count --exit-zero --select=E901,E999,F821,F822,F823 --show-source --statistics;
+      flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics; 
+    fi
 
 # command to run tests, e.g. python setup.py test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,25 @@
 sudo: false
 language: python
 cache: pip
-python:
-  - "3.6"
-  - "3.5"
-  - "3.4"
-  - "2.7"
+
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 
 install:
   - python setup.py install
 
 before_script:
+  # Run flake8 tests only on Python 2.7 and 3.7...
   # 1) stop the build if there are Python syntax errors or undefined names
   # 2) exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  # - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then
+  - if [[ $TRAVIS_PYTHON_VERSION == *.7 ]]; then
       pip install flake8;
       flake8 . --count --exit-zero --select=E901,E999,F821,F822,F823 --show-source --statistics;
       flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics; 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ install:
 before_script:
   # 1) stop the build if there are Python syntax errors or undefined names
   # 2) exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then
+  # - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then
       pip install flake8;
       flake8 . --count --exit-zero --select=E901,E999,F821,F822,F823 --show-source --statistics;
       flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics; 


### PR DESCRIPTION
Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.
* Remove versions of Python that are EOL like Python 2.6 and 3.3
    * https://docs.python.org/devguide/index.html#branchstatus

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree