### PR TITLE
Add Python 3.6 trove classifier to document support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,8 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
     "License :: OSI Approved",
     "License :: OSI Approved :: MIT License",
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
Python 3.6 support was added in 7a1f48ee1fc357692a8e2fb292b093480fdbd7b1.

Document general Python 2 support as well.