### PR TITLE
Undocument support for EOL Python 2.6 and 3.3

### DIFF
--- a/TESTING.txt
+++ b/TESTING.txt
@@ -1,4 +1,4 @@
-Currently the tests are passing on OS X and Linux on Python 2.6, 2.7, 3.3 and 3.4.
+Currently the tests are passing on OS X and Linux on Python 2.7 and 3.4.
 
 The test suite can be run either with:
 

--- a/docs/compatible_idioms.rst
+++ b/docs/compatible_idioms.rst
@@ -16,8 +16,8 @@ video is here: http://www.youtube.com/watch?v=KOqk8j11aAI&t=10m14s.)
 
 Minimum versions:
 
--  Python 2: 2.6+
--  Python 3: 3.3+
+-  Python 2: 2.7+
+-  Python 3: 3.4+
 
 Setup
 -----
@@ -1188,38 +1188,6 @@ commands / subprocess modules
     standard_library.install_aliases()
 
     from subprocess import getoutput, getstatusoutput
-subprocess.check\_output()
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. code:: python
-
-    # Python 2.7 and above
-    from subprocess import check_output
-
-    # Python 2.6 and above: alternative 1
-    from future.moves.subprocess import check_output
-
-    # Python 2.6 and above: alternative 2
-    from future import standard_library
-    standard_library.install_aliases()
-
-    from subprocess import check_output
-collections: Counter and OrderedDict
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. code:: python
-
-    # Python 2.7 and above
-    from collections import Counter, OrderedDict
-
-    # Python 2.6 and above: alternative 1
-    from future.moves.collections import Counter, OrderedDict
-
-    # Python 2.6 and above: alternative 2
-    from future import standard_library
-    standard_library.install_aliases()
-
-    from collections import Counter, OrderedDict
 StringIO module
 ~~~~~~~~~~~~~~~
 

--- a/docs/dev_notes.rst
+++ b/docs/dev_notes.rst
@@ -1,6 +1,6 @@
 Notes
 -----
-This module only supports Python 2.6, Python 2.7, and Python 3.1+.
+This module only supports Python 2.7, and Python 3.4+.
 
 The following renames are already supported on Python 2.7 without any
 additional work from us::
@@ -14,8 +14,3 @@ Old things that can one day be fixed automatically by futurize.py::
 
   string.uppercase -> string.ascii_uppercase   # works on either Py2.7 or Py3+
   sys.maxint -> sys.maxsize      # but this isn't identical
-
-TODO: Check out these:
-Not available on Py2.6:
-  unittest2 -> unittest?
-  buffer -> memoryview?

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -10,7 +10,7 @@ The easiest way to start developing ``python-future`` is as follows:
 2. Run::
 
     conda install -n future2 python=2.7 pip
-    conda install -n future3 python=3.3 pip
+    conda install -n future3 python=3.4 pip
 
     git clone https://github.com/PythonCharmers/python-future
 

--- a/docs/dict_object.rst
+++ b/docs/dict_object.rst
@@ -27,7 +27,7 @@ call to ``items``, ``values`` or ``keys``.
 
 For improved efficiency, ``future.builtins`` (aliased to ``builtins``) provides
 a Python 2 ``dict`` subclass whose :func:`keys`, :func:`values`, and
-:func:`items` methods return iterators on all versions of Python >= 2.6. On
+:func:`items` methods return iterators on all versions of Python >= 2.7. On
 Python 2.7, these iterators also have the same set-like view behaviour as
 dictionaries in Python 3. This can streamline code that iterates over large
 dictionaries. For example::
@@ -42,10 +42,6 @@ dictionaries. For example::
 
     # Because items() is memory-efficient, so is this:
     d2 = dict((v, k) for (k, v) in d.items())
-
-
-On Python 2.6, these methods currently return iterators but do not support the
-new Py3 set-like behaviour.
 
 As usual, on Python 3 ``dict`` imported from either ``builtins`` or
 ``future.builtins`` is just the built-in ``dict`` class.
@@ -90,7 +86,7 @@ The memory-efficient (and CPU-efficient) alternatives are:
     # Set union:
     both = viewvalues(d1) | viewvalues(d2)
 
-For Python 2.6 compatibility, the functions ``iteritems`` etc. are also
-available in :mod:`future.utils`. These are equivalent to the functions of the
-same names in ``six``, which is equivalent to calling the ``iteritems`` etc.
-methods on Python 2, or to calling ``items`` etc. on Python 3.
+For compatibility, the functions ``iteritems`` etc. are also available in
+:mod:`future.utils`. These are equivalent to the functions of the same names in
+``six``, which is equivalent to calling the ``iteritems`` etc. methods on
+Python 2, or to calling ``items`` etc. on Python 3.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -5,10 +5,10 @@ Who is this for?
 ================
 
 1. People with existing or new Python 3 codebases who wish to provide
-ongoing Python 2.6 / 2.7 support easily and with little maintenance burden.
+ongoing Python 2.7 support easily and with little maintenance burden.
 
 2. People who wish to ease and accelerate migration of their Python 2 codebases
-to Python 3.3+, module by module, without giving up Python 2 compatibility.
+to Python 3.4+, module by module, without giving up Python 2 compatibility.
 
 
 Why upgrade to Python 3?
@@ -217,7 +217,7 @@ complete set of support for Python 3's features, including backports of
 Python 3 builtins such as the ``bytes`` object (which is very different
 to Python 2's ``str`` object) and several standard library modules.
 
-``python-future`` supports only Python 2.6+ and Python 3.3+, whereas ``six``
+``python-future`` supports only Python 2.7+ and Python 3.4+, whereas ``six``
 supports all versions of Python from 2.4 onwards. (See
 :ref:`supported-versions`.) If you must support older Python versions,
 ``six`` will be esssential for you. However, beware that maintaining
@@ -225,7 +225,7 @@ single-source compatibility with older Python versions is ugly and `not
 fun <http://lucumr.pocoo.org/2013/5/21/porting-to-python-3-redux/>`_.
 
 If you can drop support for older Python versions, ``python-future`` leverages
-some important features introduced into Python 2.6 and 2.7, such as
+some important features introduced into Python 2.7, such as
 import hooks, and a comprehensive and well-tested set of backported
 functionality, to allow you to write more idiomatic, maintainable code with
 fewer compatibility hacks.
@@ -257,19 +257,13 @@ Platform and version support
 Which versions of Python does ``python-future`` support?
 --------------------------------------------------------
 
-Python 2.6, 2.7, and 3.3+ only.
+Python 2.7, and 3.4+ only.
 
-Python 2.6 and 2.7 introduced many important forward-compatibility
+Python 2.7 introduced many important forward-compatibility
 features (such as import hooks, ``b'...'`` literals and ``__future__``
 definitions) that greatly reduce the maintenance burden for single-source
 Py2/3 compatible code. ``future`` leverages these features and aims to
-close the remaining gap between Python 3 and 2.6 / 2.7.
-
-Python 3.2 could perhaps be supported too, although the illegal unicode
-literal ``u'...'`` syntax may be inconvenient to work around. The Py3.2
-userbase is very small, however. Please let us know via GitHub `issue #29
-<https://github.com/PythonCharmers/python-future/issues/29>`_ if you
-would like to see Py3.2 support.
+close the remaining gap between Python 3 and 2.7.
 
 
 Do you support Pypy?

--- a/docs/futurize.rst
+++ b/docs/futurize.rst
@@ -23,7 +23,7 @@ This applies fixes that modernize Python 2 code without changing the effect of
 the code. With luck, this will not introduce any bugs into the code, or will at
 least be trivial to fix. The changes are those that bring the Python code
 up-to-date without breaking Py2 compatibility. The resulting code will be
-modern Python 2.6-compatible code plus ``__future__`` imports from the
+modern Python 2.7-compatible code plus ``__future__`` imports from the
 following set:
 
 .. code-block:: python
@@ -151,7 +151,7 @@ method on exceptions.
 
     lib2to3.fixes.fix_set_literal
 
-This converts ``set([1, 2, 3]``) to ``{1, 2, 3}``, breaking Python 2.6 support.
+This converts ``set([1, 2, 3]``) to ``{1, 2, 3}``.
 
 .. code-block:: python
 

--- a/docs/futurize_cheatsheet.rst
+++ b/docs/futurize_cheatsheet.rst
@@ -13,7 +13,7 @@ Step 0: setup
 Step 0 goal: set up and see the tests passing on Python 2 and failing on Python 3.
 
 a. Clone the package from github/bitbucket. Optionally rename your repo to ``package-future``. Examples: ``reportlab-future``, ``paramiko-future``, ``mezzanine-future``.
-b. Create and activate a Python 2 conda environment or virtualenv. Install the package with ``python setup.py install`` and run its test suite on Py2.7 or Py2.6 (e.g. ``python setup.py test`` or ``py.test``)
+b. Create and activate a Python 2 conda environment or virtualenv. Install the package with ``python setup.py install`` and run its test suite on Py2.7 (e.g. ``python setup.py test`` or ``py.test``)
 c. Optionally: if there is a ``.travis.yml`` file, add Python version 3.6 and remove any versions < 2.6.
 d. Install Python 3 with e.g. ``sudo apt-get install python3``. On other platforms, an easy way is to use `Miniconda <http://repo.continuum.io/miniconda/index.html>`_. Then e.g.::
 

--- a/docs/futurize_overview.rst
+++ b/docs/futurize_overview.rst
@@ -51,5 +51,5 @@ use the ``-w`` flag.
 
 For complex projects, it is probably best to divide the porting into two stages.
 Stage 1 is for "safe" changes that modernize the code but do not break Python
-2.6 compatibility or introduce a depdendency on the ``future`` package. Stage 2
+2.7 compatibility or introduce a depdendency on the ``future`` package. Stage 2
 is to complete the process.

--- a/docs/imports.rst
+++ b/docs/imports.rst
@@ -24,7 +24,7 @@ standard feature of Python, see the following docs:
 - print_function: `PEP 3105: Make print a function <http://www.python.org/dev/peps/pep-3105>`_
 - unicode_literals: `PEP 3112: Bytes literals in Python 3000 <http://www.python.org/dev/peps/pep-3112>`_
 
-These are all available in Python 2.6 and up, and enabled by default in Python 3.x.
+These are all available in Python 2.7 and up, and enabled by default in Python 3.x.
 
 
 .. _builtins-imports:

--- a/docs/open_function.rst
+++ b/docs/open_function.rst
@@ -13,7 +13,7 @@ in which case its methods like :func:`read` return Py3 :class:`bytes` objects.
 On Py2 with ``future`` installed, the :mod:`builtins` module provides an
 ``open`` function that is mostly compatible with that on Python 3 (e.g. it
 offers keyword arguments like ``encoding``). This maps to the ``open`` backport
-available in the standard library :mod:`io` module on Py2.6 and Py2.7.
+available in the standard library :mod:`io` module on Py2.7.
 
 One difference to be aware of between the Python 3 ``open`` and
 ``future.builtins.open`` on Python 2 is that the return types of methods such

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -19,16 +19,6 @@ To install the latest stable version, type::
 If you would prefer the latest development version, it is available `here
 <https://github.com/PythonCharmers/python-future>`_.
 
-On Python 2.6, three packages containing backports of standard library modules
-in Python 2.7+ are needed for small parts of the code::
-
-    pip install importlib       # for future.standard_library.import_ function only
-    pip install unittest2       # to run the test suite
-    pip install argparse        # for the backported http.server module from Py3.3
-
-Unless these features are used on Python 2.6 (only), ``future`` has no
-dependencies.
-
 
 If you are writing code from scratch
 ------------------------------------
@@ -40,7 +30,7 @@ The easiest way is to start each new module with these lines::
     from builtins import *
 
 Then write standard Python 3 code. The :mod:`future` package will
-provide support for running your code on Python 2.6, 2.7, and 3.3+ mostly
+provide support for running your code on Python 2.7, and 3.4+ mostly
 unchanged.
 
 - For explicit import forms, see :ref:`explicit-imports`.
@@ -101,7 +91,7 @@ to be accessed under their Python 3 names and locations in Python 2::
     import socketserver
     import queue
     from collections import UserDict, UserList, UserString
-    from collections import Counter, OrderedDict, ChainMap   # even on Py2.6
+    from collections import ChainMap  # even on Py2.7
     from itertools import filterfalse, zip_longest
 
     import html

--- a/docs/standard_library_imports.rst
+++ b/docs/standard_library_imports.rst
@@ -85,7 +85,7 @@ Note that, as of v0.16.0, ``python-future`` no longer includes an alias for the
 Aliased imports
 ~~~~~~~~~~~~~~~
 
-The following 14 modules were refactored or extended from Python 2.6/2.7 to 3.x
+The following 14 modules were refactored or extended from Python 2.7 to 3.x
 but were neither renamed in Py3.x nor were the new APIs backported to Py2.x.
 This precludes compatibility interfaces that work out-of-the-box. Instead, the
 ``future`` package makes the Python 3.x APIs available on Python 2.x as
@@ -129,22 +129,16 @@ HTTPS (as of 2015-09-11) because the SSL support changed considerably in Python
 Backports also exist of the following features from Python 3.4:
 
 - ``math.ceil`` returns an int on Py3
-- ``collections.OrderedDict``  (for Python 2.6)
-- ``collections.Counter``      (for Python 2.6)
-- ``collections.ChainMap``     (for all versions prior to Python 3.3)
-- ``itertools.count``          (for Python 2.6, with step parameter)
-- ``subprocess.check_output``  (for Python 2.6)
-- ``reprlib.recursive_repr``   (for Python 2.6 and 2.7)
+- ``collections.ChainMap``     (for 2.7)
+- ``reprlib.recursive_repr``   (for 2.7)
 
-These can then be imported on Python 2.6+ as follows::
+These can then be imported on Python 2.7+ as follows::
 
     from future.standard_library import install_aliases
     install_aliases()
 
     from math import ceil      # now returns an int
-    from collections import Counter, OrderedDict, ChainMap
-    from itertools import count
-    from subprocess import check_output
+    from collections import ChainMap
     from reprlib import recursive_repr
 
 
@@ -158,20 +152,11 @@ available independently of the python-future project::
     import singledispatch             # pip install singledispatch
     import pathlib                    # pip install pathlib
 
-A few modules from Python 3.4 and 3.3 are also available in the ``backports``
+A few modules from Python 3.4 are also available in the ``backports``
 package namespace after ``pip install backports.lzma`` etc.::
 
     from backports import lzma
     from backports import functools_lru_cache as lru_cache
-
-The following Python 2.6 backports of standard library packages from Python 2.7+
-are also available::
-
-    import argparse                   # pip install argparse
-    import importlib                  # pip install importlib
-    import unittest2 as unittest      # pip install unittest2
-
-These are included in Python 2.7 and Python 3.x.
 
 
 Included full backports

--- a/requirements_py26.txt
+++ b/requirements_py26.txt
@@ -1,3 +1,0 @@
-unittest2
-argparse     # for the http.server module
-importlib

--- a/setup.py
+++ b/setup.py
@@ -85,11 +85,6 @@ PACKAGE_DATA = {'': [
                 'tests': ['*.py'],
                 }
 
-REQUIRES = []
-TEST_REQUIRES = []
-if sys.version_info[:2] == (2, 6):
-    REQUIRES += ['importlib', 'argparse']
-    TEST_REQUIRES += ['unittest2']
 import src.future
 VERSION = src.future.__version__
 DESCRIPTION = "Clean single-source support for Python 3 and 2"
@@ -101,10 +96,9 @@ LICENSE = "MIT"
 KEYWORDS = "future past python3 migration futurize backport six 2to3 modernize pasteurize 3to2"
 CLASSIFIERS = [
     "Programming Language :: Python",
-    "Programming Language :: Python :: 2.6",
+    "Programming Language :: Python :: 2",
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.3",
     "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",
     "License :: OSI Approved",
@@ -179,9 +173,8 @@ setup(name=NAME,
       packages=PACKAGES,
       package_data=PACKAGE_DATA,
       include_package_data=True,
-      install_requires=REQUIRES,
+      python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
       classifiers=CLASSIFIERS,
       test_suite = "discover_tests",
-      tests_require=TEST_REQUIRES,
       **setup_kwds
      )


### PR DESCRIPTION
Python 2.6 and 3.3 are end of life. They are no longer receiving bug fixes, including for security issues. Python 2.6 went EOL on 2013-10-29 and on 2017-09-29. For additional details on support Python versions, see:

https://devguide.python.org/#status-of-python-branches

Removing support for EOL Pythons will reduce testing and maintenance resources.

Using pypinfo, here are the PyPI download statistics for the last 30 days, showing low numbers for these EOL Pythons:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  56.49% |      3,841,256 |
| 3.6            |  30.41% |      2,067,785 |
| 3.5            |   8.38% |        569,774 |
| 3.4            |   3.15% |        214,075 |
| 3.7            |   1.50% |        102,095 |
| 2.6            |   0.04% |          2,960 |
| 3.3            |   0.02% |          1,236 |
| 3.8            |   0.00% |             84 |
| 3.2            |   0.00% |             46 |
| None           |   0.00% |             33 |

https://github.com/ofek/pypinfo

This change only removes the documentation of 2.6 and 3.3. Legacy code is expected to be removed in future commits as the changes are quite extensive.