### PR TITLE
Fix for issue #262 (non-existing tkinter imports in older py27 versions)

### DIFF
--- a/src/future/moves/tkinter/__init__.py
+++ b/src/future/moves/tkinter/__init__.py
@@ -4,8 +4,24 @@ __future_module__ = True
 
 if not PY3:
     from Tkinter import *
-    from Tkinter import (_cnfmerge, _default_root, _flatten, _join, _setit,
-                         _splitdict, _stringify, _support_default_root, _test,
-                         _tkinter)
+    from Tkinter import (_cnfmerge, _default_root, _flatten,
+                          _support_default_root, _test,
+                         _tkinter, _setit)
+
+    try: # >= 2.7.4
+        from Tkinter import (_join) 
+    except ImportError: 
+        pass
+
+    try: # >= 2.7.4
+        from Tkinter import (_stringify)
+    except ImportError: 
+        pass
+
+    try: # >= 2.7.9
+        from Tkinter import (_splitdict)
+    except ImportError:
+        pass
+
 else:
     from tkinter import *

--- a/src/tkinter/__init__.py
+++ b/src/tkinter/__init__.py
@@ -3,9 +3,25 @@ import sys
 
 if sys.version_info[0] < 3:
     from Tkinter import *
-    from Tkinter import (_cnfmerge, _default_root, _flatten, _join, _setit,
-                         _splitdict, _stringify, _support_default_root, _test,
-                         _tkinter)
+    from Tkinter import (_cnfmerge, _default_root, _flatten,
+                          _support_default_root, _test,
+                         _tkinter, _setit)
+
+    try: # >= 2.7.4
+        from Tkinter import (_join) 
+    except ImportError: 
+        pass
+
+    try: # >= 2.7.4
+        from Tkinter import (_stringify)
+    except ImportError: 
+        pass
+
+    try: # >= 2.7.9
+        from Tkinter import (_splitdict)
+    except ImportError:
+        pass
+
 else:
     raise ImportError('This package should not be accessible on Python 3. '
                       'Either you are trying to run from the python-future src folder '


### PR DESCRIPTION
Fix for issue #262 

Some of the imports introduced in #233 are not compatible with Python versions prior to 2.7.9.
Specifically, _join and _stringify seem to have been introduced in 2.7.4, and _splitdict in 2.7.9.