### PR TITLE
Remove an unnecessary 'main' import

### DIFF
--- a/src/libfuturize/main.py
+++ b/src/libfuturize/main.py
@@ -70,7 +70,7 @@ import logging
 import optparse
 import os
 
-from lib2to3.main import main, warn, StdoutRefactoringTool
+from lib2to3.main import warn, StdoutRefactoringTool
 from lib2to3 import refactor
 
 from libfuturize.fixes import (lib2to3_fix_names_stage1,


### PR DESCRIPTION
We don't use `lib2to3.main.main`, and we define our own `main()` which
was shadowing this import.