### PR TITLE
newrange: handle non-numbers passed to index()

### DIFF
--- a/src/future/types/newrange.py
+++ b/src/future/types/newrange.py
@@ -90,7 +90,10 @@ class newrange(Sequence):
     def index(self, value):
         """Return the 0-based position of integer `value` in
         the sequence this range represents."""
-        diff = value - self._start
+        try:
+            diff = value - self._start
+        except TypeError:
+            raise ValueError('%r is not in range' % value)
         quotient, remainder = divmod(diff, self._step)
         if remainder == 0 and 0 <= quotient < self._len:
             return abs(quotient)

--- a/tests/test_future/test_range.py
+++ b/tests/test_future/test_range.py
@@ -26,6 +26,12 @@ class RangeTests(unittest.TestCase):
         self.assertEqual(range(0), range(1, 1))
         self.assertEqual(range(0, 10, 3), range(0, 11, 3))
 
+    def test_contains(self):
+        self.assertIn(1, range(2))
+        self.assertNotIn(10, range(2))
+        self.assertNotIn(None, range(2))
+        self.assertNotIn("", range(2))
+
     # Use strict equality of attributes when slicing to catch subtle differences
     def assertRangesEqual(self, r1, r2):
         by_attrs = attrgetter('start', 'stop', 'step')


### PR DESCRIPTION
These kinds of operations failed with a TypeError when a non-numeric
value is given:

    >>> None in newrange(10)
    >>> newrange(10).index(None)

We now catch the initial TypeError in newrange.index() and return the
ValueError result immediately.

I also considered adding an int(value) conversion, but that isn't
consistent with the standard library's range() behavior. For example:

    >> "1" in range(10)
    False