### PR TITLE
Fix tests on Py3

### DIFF
--- a/src/future/utils/__init__.py
+++ b/src/future/utils/__init__.py
@@ -56,7 +56,7 @@ import inspect
 
 
 PY3 = sys.version_info[0] == 3
-PY35 = sys.version_info[0:2] >= (3, 5)
+PY35_PLUS = sys.version_info[0:2] >= (3, 5)
 PY2 = sys.version_info[0] == 2
 PY26 = sys.version_info[0:2] == (2, 6)
 PY27 = sys.version_info[0:2] == (2, 7)

--- a/src/future/utils/__init__.py
+++ b/src/future/utils/__init__.py
@@ -57,6 +57,7 @@ import inspect
 
 PY3 = sys.version_info[0] == 3
 PY35_PLUS = sys.version_info[0:2] >= (3, 5)
+PY36_PLUS = sys.version_info[0:2] >= (3, 6)
 PY2 = sys.version_info[0] == 2
 PY26 = sys.version_info[0:2] == (2, 6)
 PY27 = sys.version_info[0:2] == (2, 7)

--- a/tests/test_future/test_bytes.py
+++ b/tests/test_future/test_bytes.py
@@ -566,7 +566,7 @@ class TestBytes(unittest.TestCase):
 
         self.assertEqual(bytes(b'%(foo)s') % d, b'bar')
 
-    @unittest.skipUnless(utils.PY35 or utils.PY2,
+    @unittest.skipUnless(utils.PY35_PLUS or utils.PY2,
                          'test requires Python 2 or 3.5+')
     def test_mod_more(self):
         self.assertEqual(b'%s' % b'aaa', b'aaa')
@@ -577,10 +577,10 @@ class TestBytes(unittest.TestCase):
         self.assertEqual(bytes(b'%s') % (b'aaa',), b'aaa')
         self.assertEqual(bytes(b'%s') % (bytes(b'aaa'),), b'aaa')
 
-        self.assertEqual(bytes(b'%(x)s') % {'x': b'aaa'}, b'aaa')
-        self.assertEqual(bytes(b'%(x)s') % {'x': bytes(b'aaa')}, b'aaa')
+        self.assertEqual(bytes(b'%(x)s') % {b'x': b'aaa'}, b'aaa')
+        self.assertEqual(bytes(b'%(x)s') % {b'x': bytes(b'aaa')}, b'aaa')
 
-    @unittest.skipUnless(utils.PY35 or utils.PY2,
+    @unittest.skipUnless(utils.PY35_PLUS or utils.PY2,
                          'test requires Python 2 or 3.5+')
     def test_mod(self):
         """
@@ -606,7 +606,7 @@ class TestBytes(unittest.TestCase):
         a = b % (bytes(b'seventy-nine'), 79)
         self.assertEqual(a, b'seventy-nine / 100 = 79%')
 
-    @unittest.skipUnless(utils.PY35 or utils.PY2,
+    @unittest.skipUnless(utils.PY35_PLUS or utils.PY2,
                          'test requires Python 2 or 3.5+')
     def test_imod(self):
         """

--- a/tests/test_future/test_urllibnet.py
+++ b/tests/test_future/test_urllibnet.py
@@ -109,9 +109,8 @@ class urlopenNetworkTests(unittest.TestCase):
 
     # On Windows, socket handles are not file descriptors; this
     # test can't pass on Windows.
-    #
-    # On macOS, this behavior is undocumented and this test fails.
-    @unittest.skipIf(sys.platform in ('darwin', 'win32',), 'not appropriate for macOS or Windows')
+    @unittest.skipIf(sys.platform in ('darwin', 'win32',), 'not appropriate for Windows')
+    @unittest.skipIf(utils.PY36_PLUS, 'test not applicable on Python 3.5 and higher')
     @skip26
     def test_fileno(self):
         # Make sure fd returned by fileno is valid.

--- a/tests/test_future/test_urllibnet.py
+++ b/tests/test_future/test_urllibnet.py
@@ -109,7 +109,9 @@ class urlopenNetworkTests(unittest.TestCase):
 
     # On Windows, socket handles are not file descriptors; this
     # test can't pass on Windows.
-    @unittest.skipIf(sys.platform in ('win32',), 'not appropriate for Windows')
+    #
+    # On macOS, this behavior is undocumented and this test fails.
+    @unittest.skipIf(sys.platform in ('darwin', 'win32',), 'not appropriate for macOS or Windows')
     @skip26
     def test_fileno(self):
         # Make sure fd returned by fileno is valid.


### PR DESCRIPTION
This change brings our test running suite green for all environments.  It includes:
- Rename the PY35 constant to PY35_PLUS, which is a bit more accurate as it is valid for .e.g Py3.6.
- Bring a failed test case in-line with the behavior for the cpython interpreter.
- Incorporate @jparise's change in #391 