### PR TITLE
Mark wheel as not universal, closes #399

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-universal = 1
-
 [metadata]
 license_file = LICENSE.txt


### PR DESCRIPTION
Future wheel provides different sets of modules and packages for Python-2 and Python-3 thus wheel must not be marked as universal.