### PR TITLE
Revert "Bail if building with Py3"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,6 @@ try:
 except ImportError:
     from distutils.core import setup
 
-if sys.argv[-1] == 'sdist' and sys.version_info[0] >= 3:
-    print('ERROR: You must build python-future with Python 2', file=sys.stderr)
-    sys.exit(1)
 
 if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')


### PR DESCRIPTION
I would suggest to revert the change that prevents from building an `sdist` under Python 3.

I've followed the #398 and #399 issues, and both were addressed by PR #400 

The only compatibility issue was for **wheels** built under Python 3 (with `python setup.py bdist_wheel`) and then used under Python 2, and that was only because **wheels** where considered universal, while they aren't, and that's now addressed by PR #400.

Building an `sdist` (`.tar.gz`/`.zip` format) and using it across Python 2/3 isn't an issue, as the `setup.py` file will be executed in each instance and will install only the right parts. Thus, running `python setup.py sdist` on python 3 is entirely valid, and preventing it will cause issue for users.

I suggest to revert it before releasing v0.17.1.