### PR TITLE
Fix deprecation warnings for abc module in Python 3.7

### DIFF
--- a/src/past/builtins/misc.py
+++ b/src/past/builtins/misc.py
@@ -1,13 +1,12 @@
 from __future__ import unicode_literals
-import sys
+
 import inspect
-from collections import Mapping
 
 from future.utils import PY3, exec_
 
-
 if PY3:
     import builtins
+    from collections.abc import Mapping
 
     def apply(f, *args, **kw):
         return f(*args, **kw)
@@ -44,6 +43,7 @@ if PY3:
     xrange = range
 else:
     import __builtin__
+    from collections import Mapping
     apply = __builtin__.apply
     chr = __builtin__.chr
     cmp = __builtin__.cmp

--- a/src/past/types/oldstr.py
+++ b/src/past/types/oldstr.py
@@ -2,11 +2,9 @@
 Pure-Python implementation of a Python 2-like str object for Python 3.
 """
 
-from collections import Iterable
 from numbers import Integral
 
-from past.utils import PY2, with_metaclass
-
+from past.utils import with_metaclass
 
 _builtin_bytes = bytes
 


### PR DESCRIPTION
Fixes #415:

1. In Python 3, import Mapping from collections.abc, in Python 2 continues to import from collections
2. Removes an import of collections Iterable since it wasn't being used in the module

Signed-off-by: Dan Yeaw <dan@yeaw.me>