### PR TITLE
socket.fp has no readinto

### DIFF
--- a/src/future/backports/http/client.py
+++ b/src/future/backports/http/client.py
@@ -696,9 +696,19 @@ class HTTPResponse(io.RawIOBase):
         while total_bytes < len(b):
             if MAXAMOUNT < len(mvb):
                 temp_mvb = mvb[0:MAXAMOUNT]
-                n = self.fp.readinto(temp_mvb)
+                if PY2:
+                    data = self.fp.read(len(temp_mvb))
+                    n = len(data)
+                    temp_mvb[:n] = data
+                else:
+                    n = self.fp.readinto(temp_mvb)
             else:
-                n = self.fp.readinto(mvb)
+                if PY2:
+                    data = self.fp.read(len(mvb))
+                    n = len(data)
+                    mvb[:n] = data
+                else:
+                    n = self.fp.readinto(mvb)
             if not n:
                 raise IncompleteRead(bytes(mvb[0:total_bytes]), len(b))
             mvb = mvb[n:]


### PR DESCRIPTION
on python 2, `socket.fp` doesn't have a `readinto()` method, leading to errors like that seen here: https://github.com/kivy/kivy-ios/issues/322#issuecomment-450735812. 

Work around this limitation the same way it is worked around in `read()`; e.g. https://github.com/PythonCharmers/python-future/blob/a8114e48ce7dbc4cecbf6a764d73e83d03b0d6ba/src/future/backports/http/client.py#L556-L561