### PR TITLE
[Bugfix] email.Message.set_boundary()

### DIFF
--- a/src/future/backports/email/message.py
+++ b/src/future/backports/email/message.py
@@ -800,7 +800,7 @@ class Message(object):
             # There was no Content-Type header, and we don't know what type
             # to set it to, so raise an exception.
             raise errors.HeaderParseError('No Content-Type header found')
-        newparams = []
+        newparams = list()
         foundp = False
         for pk, pv in params:
             if pk.lower() == 'boundary':
@@ -814,10 +814,10 @@ class Message(object):
             # instead???
             newparams.append(('boundary', '"%s"' % boundary))
         # Replace the existing Content-Type header with the new value
-        newheaders = []
+        newheaders = list()
         for h, v in self._headers:
             if h.lower() == 'content-type':
-                parts = []
+                parts = list()
                 for k, v in newparams:
                     if v == '':
                         parts.append(k)

--- a/tests/test_future/test_email_multipart.py
+++ b/tests/test_future/test_email_multipart.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""Tests for multipart emails."""
+
+from future.tests.base import unittest
+import future.backports.email as email
+import future.backports.email.mime.multipart
+from future.builtins import list
+
+class EmailMultiPartTests(unittest.TestCase):
+    """Tests for handling multipart email Messages."""
+
+    def test_multipart_serialize_without_boundary(self):
+        """Tests that serializing an empty multipart email does not fail."""
+        multipart_message = email.mime.multipart.MIMEMultipart()
+        self.assertIsNot(multipart_message.as_string(), None)
+
+    def test_multipart_set_boundary_does_not_change_header_type(self):
+        """
+        Tests that Message.set_boundary() does not cause Python2 errors.
+        
+        In particular, tests that set_boundary does not cause the type of the
+        message headers list to be changed from the future built-in list.
+        """
+        multipart_message = email.mime.multipart.MIMEMultipart()
+        headers_type = type(multipart_message._headers)
+        self.assertEqual(headers_type, type(list()))
+
+        boundary = '===============6387699881409002085=='
+        multipart_message.set_boundary(boundary)
+        headers_type = type(multipart_message._headers)
+        self.assertEqual(headers_type, type(list()))


### PR DESCRIPTION
Closes #429.

A bug in `future.backports.email.Message.set_boundary` causes errors when serializing multipart email Message objects, as described in the issue.

The fix was simply to replace usages of the native python list type with the future built-in list type.

Also added tests that would expose the bug.