### PR TITLE
Revert "allow mixed string type inputs to misc urllib.parse.* functions"

### DIFF
--- a/src/future/backports/urllib/parse.py
+++ b/src/future/backports/urllib/parse.py
@@ -107,11 +107,11 @@ def _coerce_args(*args):
     # an appropriate result coercion function
     #   - noop for str inputs
     #   - encoding function otherwise
-    str_input = isinstance(args[0], basestring)
+    str_input = isinstance(args[0], str)
     for arg in args[1:]:
         # We special-case the empty string to support the
         # "scheme=''" default argument to some functions
-        if arg and isinstance(arg, basestring) != str_input:
+        if arg and isinstance(arg, str) != str_input:
             raise TypeError("Cannot mix str and non-str arguments")
     if str_input:
         return args + (_noop,)


### PR DESCRIPTION
This reverts commit 62b4c35d995aa5503855ffcc5c8fb2262e02c2a2.