### PR TITLE
Make future.moves.copyreg just _be_ copyreg on PY3

### DIFF
--- a/src/future/moves/copyreg.py
+++ b/src/future/moves/copyreg.py
@@ -2,7 +2,11 @@ from __future__ import absolute_import
 from future.utils import PY3
 
 if PY3:
-    from copyreg import *
+    import copyreg, sys
+    # A "*" import uses Python 3's copyreg.__all__ which does not include
+    # all public names in the API surface for copyreg, this avoids that
+    # problem by just making our module _be_ a reference to the actual module.
+    sys.modules['future.moves.copyreg'] = copyreg
 else:
     __future_module__ = True
     from copy_reg import *


### PR DESCRIPTION
The existing `from copyreg import *` is insufficient on Python 3 as `copyreg.__all__` does not include all of the public API names.