### PR TITLE
Don't import past.translation by default when importing past

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -243,7 +243,7 @@ Example:
 
     $ python3
 
-    >>> from past import autotranslate
+    >>> from past.translation import autotranslate
     >>> autotranslate(['plotrique'])
     >>> import plotrique
 
@@ -270,7 +270,7 @@ Licensing
 
 :Sponsors: Python Charmers Pty Ltd, Australia, and Python Charmers Pte
            Ltd, Singapore. http://pythoncharmers.com
-           
+
            Pinterest https://opensource.pinterest.com/
 
 :Licence: MIT. See ``LICENSE.txt`` or `here <http://python-future.org/credits.html>`_.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -616,10 +616,10 @@ it like this::
     $ pip3 install plotrique==0.2.5-7 --no-compile   # to ignore SyntaxErrors
     $ python3
 
-Then pass in a whitelist of module name prefixes to the ``past.autotranslate()``
-function. Example::
+Then pass in a whitelist of module name prefixes to the
+``past.translation.autotranslate()`` function. Example::
 
-    >>> from past import autotranslate
+    >>> from past.translation import autotranslate
     >>> autotranslate(['plotrique'])
     >>> import plotrique
 
@@ -949,8 +949,8 @@ v0.11.3:
     objects as on Py3.
 
 v0.11.2:
-  * The ``past.autotranslate`` feature now finds modules to import more
-    robustly and works with Python eggs.
+  * The ``past.translation.autotranslate`` feature now finds modules to import
+    more robustly and works with Python eggs.
 
 v0.11.1:
   * Update to ``requirements_py26.txt`` for Python 2.6. Small updates to

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -132,7 +132,7 @@ environment::
 Then add the following code at the top of your (Py3 or Py2/3-compatible)
 code::
 
-    from past import autotranslate
+    from past.translation import autotranslate
     autotranslate(['mypackagename'])
     import mypackagename
 

--- a/docs/translation.rst
+++ b/docs/translation.rst
@@ -21,9 +21,9 @@ Here is how to use it::
     $ python3
 
 Then pass in a whitelist of module name prefixes to the
-``past.autotranslate()`` function. Example::
+``past.translation.autotranslate()`` function. Example::
 
-    >>> from past import autotranslate
+    >>> from past.translation import autotranslate
     >>> autotranslate(['plotrique'])
     >>> import plotrique
 

--- a/src/past/__init__.py
+++ b/src/past/__init__.py
@@ -61,7 +61,7 @@ this::
 
     $ python3
 
-    >>> from past import autotranslate
+    >>> from past.translation import autotranslate
     >>> authotranslate('mypy2module')
     >>> import mypy2module
 
@@ -84,8 +84,6 @@ Copyright 2013-2018 Python Charmers Pty Ltd, Australia.
 The software is distributed under an MIT licence. See LICENSE.txt.
 """
 
-
-from past.translation import install_hooks as autotranslate
 from future import __version__, __copyright__, __license__
 
 __title__ = 'past'

--- a/src/past/translation/__init__.py
+++ b/src/past/translation/__init__.py
@@ -16,7 +16,7 @@ Usage
 Once your Py2 package is installed in the usual module search path, the import
 hook is invoked as follows:
 
-    >>> from past import autotranslate
+    >>> from past.translation import autotranslate
     >>> autotranslate('mypackagename')
 
 Or:
@@ -479,3 +479,7 @@ class suspend_hooks(object):
     def __exit__(self, *args):
         if self.hooks_were_installed:
             install_hooks()
+
+
+# alias
+autotranslate = install_hooks


### PR DESCRIPTION
There are two reasons to make this change:
- It is a waste of time to import all of the `lib2to3` package just to do e.g. `from past import unicode`
- More importantly, the import of `lib2to3` does not work on certain python distributions, including zipped python installations.  See issue #209 on this repo and this [core python issue](https://bugs.python.org/issue24960). 

This is a backward incompatible change due to the change of location for `autotranslate`, but I think it's the right thing to do for the start of the version 18.x line.

(edited for clarity)