### PR TITLE
fix collections abc import for py38

### DIFF
--- a/src/future/backports/http/client.py
+++ b/src/future/backports/http/client.py
@@ -79,10 +79,14 @@ from future.backports.misc import create_connection as socket_create_connection
 import io
 import os
 import socket
-import collections
 from future.backports.urllib.parse import urlsplit
 import warnings
 from array import array
+
+if PY2:
+    from collections import Iterable
+else:
+    from collections.abc import Iterable
 
 __all__ = ["HTTPResponse", "HTTPConnection",
            "HTTPException", "NotConnected", "UnknownProtocol",
@@ -902,7 +906,7 @@ class HTTPConnection(object):
         try:
             self.sock.sendall(data)
         except TypeError:
-            if isinstance(data, collections.Iterable):
+            if isinstance(data, Iterable):
                 for d in data:
                     self.sock.sendall(d)
             else:

--- a/src/future/types/newbytes.py
+++ b/src/future/types/newbytes.py
@@ -5,14 +5,18 @@ Why do this? Without it, the Python 2 bytes object is a very, very
 different beast to the Python 3 bytes object.
 """
 
-from collections import Iterable
 from numbers import Integral
 import string
 import copy
 
-from future.utils import istext, isbytes, PY3, with_metaclass
+from future.utils import istext, isbytes, PY2, PY3, with_metaclass
 from future.types import no, issubset
 from future.types.newobject import newobject
+
+if PY2:
+    from collections import Iterable
+else:
+    from collections.abc import Iterable
 
 
 _builtin_bytes = bytes

--- a/src/future/types/newint.py
+++ b/src/future/types/newint.py
@@ -8,7 +8,6 @@ They are very similar. The most notable difference is:
 from __future__ import division
 
 import struct
-import collections
 
 from future.types.newbytes import newbytes
 from future.types.newobject import newobject
@@ -17,6 +16,9 @@ from future.utils import PY3, isint, istext, isbytes, with_metaclass, native
 
 if PY3:
     long = int
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
 
 
 class BaseNewInt(type):
@@ -356,7 +358,7 @@ class newint(with_metaclass(BaseNewInt, long)):
             raise TypeError("cannot convert unicode objects to bytes")
         # mybytes can also be passed as a sequence of integers on Py3.
         # Test for this:
-        elif isinstance(mybytes, collections.Iterable):
+        elif isinstance(mybytes, Iterable):
             mybytes = newbytes(mybytes)
         b = mybytes if byteorder == 'big' else mybytes[::-1]
         if len(b) == 0:

--- a/src/future/types/newmemoryview.py
+++ b/src/future/types/newmemoryview.py
@@ -1,14 +1,16 @@
 """
 A pretty lame implementation of a memoryview object for Python 2.6.
 """
-
-from collections import Iterable
 from numbers import Integral
 import string
 
-from future.utils import istext, isbytes, PY3, with_metaclass
+from future.utils import istext, isbytes, PY2, with_metaclass
 from future.types import no, issubset
 
+if PY2:
+    from collections import Iterable
+else:
+    from collections.abc import Iterable
 
 # class BaseNewBytes(type):
 #     def __instancecheck__(cls, instance):

--- a/src/future/types/newrange.py
+++ b/src/future/types/newrange.py
@@ -19,7 +19,12 @@ From Dan Crosta's README:
 """
 from __future__ import absolute_import
 
-from collections import Sequence, Iterator
+from future.utils import PY2
+
+if PY2:
+    from collections import Sequence, Iterator
+else:
+    from collections.abc import Sequence, Iterator
 from itertools import islice
 
 from future.backports.misc import count   # with step parameter on Py2.6

--- a/src/future/types/newstr.py
+++ b/src/future/types/newstr.py
@@ -40,7 +40,6 @@ representations of your objects portably across Py3 and Py2, use the
 
 """
 
-from collections import Iterable
 from numbers import Number
 
 from future.utils import PY3, istext, with_metaclass, isnewbytes
@@ -51,6 +50,9 @@ from future.types.newobject import newobject
 if PY3:
     # We'll probably never use newstr on Py3 anyway...
     unicode = str
+    from collections.abc import Iterable
+else:
+    from collections import Iterable
 
 
 class BaseNewStr(type):


### PR DESCRIPTION
I know we're getting close to Py2 sunset anyway, but for sake of Python 3.8 compatibility of last Py2 releases, I think abc should be handled, I'm seeing some deprecation warnings and Py38 is on the doorstep.