### PR TITLE
Fix min/max functions with generators, and 'None' default

### DIFF
--- a/src/future/builtins/new_min_max.py
+++ b/src/future/builtins/new_min_max.py
@@ -1,3 +1,5 @@
+import itertools
+
 from future import utils
 if utils.PY2:
     from __builtin__ import max as _builtin_max, min as _builtin_min
@@ -33,17 +35,20 @@ def new_min_max(_builtin_func, *args, **kwargs):
         raise TypeError
 
     if len(args) == 1:
+        iterator = iter(args[0])
         try:
-            next(iter(args[0]))
+            first = next(iterator)
         except StopIteration:
             if kwargs.get('default') is not None:
                 return kwargs.get('default')
             else:
                 raise ValueError('iterable is an empty sequence')
-        if kwargs.get('key') is not None:
-            return _builtin_func(args[0], key=kwargs.get('key'))
         else:
-            return _builtin_func(args[0])
+            iterator = itertools.chain([first], iterator)
+        if kwargs.get('key') is not None:
+            return _builtin_func(iterator, key=kwargs.get('key'))
+        else:
+            return _builtin_func(iterator)
 
     if len(args) > 1:
         if kwargs.get('key') is not None:

--- a/src/future/builtins/new_min_max.py
+++ b/src/future/builtins/new_min_max.py
@@ -44,7 +44,7 @@ def new_min_max(_builtin_func, *args, **kwargs):
             if kwargs.get('default', _SENTINEL) is not _SENTINEL:
                 return kwargs.get('default')
             else:
-                raise ValueError('iterable is an empty sequence')
+                raise ValueError('{}() arg is an empty sequence'.format(_builtin_func.__name__))
         else:
             iterator = itertools.chain([first], iterator)
         if kwargs.get('key') is not None:

--- a/src/future/builtins/new_min_max.py
+++ b/src/future/builtins/new_min_max.py
@@ -6,6 +6,8 @@ if utils.PY2:
 else:
     from builtins import max as _builtin_max, min as _builtin_min
 
+_SENTINEL = object()
+
 
 def newmin(*args, **kwargs):
     return new_min_max(_builtin_min, *args, **kwargs)
@@ -31,7 +33,7 @@ def new_min_max(_builtin_func, *args, **kwargs):
     if len(args) == 0:
         raise TypeError
 
-    if len(args) != 1 and kwargs.get('default') is not None:
+    if len(args) != 1 and kwargs.get('default', _SENTINEL) is not _SENTINEL:
         raise TypeError
 
     if len(args) == 1:
@@ -39,7 +41,7 @@ def new_min_max(_builtin_func, *args, **kwargs):
         try:
             first = next(iterator)
         except StopIteration:
-            if kwargs.get('default') is not None:
+            if kwargs.get('default', _SENTINEL) is not _SENTINEL:
                 return kwargs.get('default')
             else:
                 raise ValueError('iterable is an empty sequence')

--- a/tests/test_future/test_builtins.py
+++ b/tests/test_future/test_builtins.py
@@ -1123,6 +1123,7 @@ class BuiltinTest(unittest.TestCase):
             def __getitem__(self, index):
                 raise ValueError
         self.assertRaises(ValueError, min, BadSeq())
+        self.assertEqual(max(x for x in [5, 4, 3]), 5)
 
         for stmt in (
             "min(key=int)",                 # no args
@@ -1156,7 +1157,6 @@ class BuiltinTest(unittest.TestCase):
 
         # Test iterables that can only be looped once #510
         self.assertEqual(min(x for x in [5]), 5)
-        self.assertEqual(max(x for x in [5, 4, 3]), 5)
 
     def test_next(self):
         it = iter(range(2))

--- a/tests/test_future/test_builtins.py
+++ b/tests/test_future/test_builtins.py
@@ -1154,6 +1154,10 @@ class BuiltinTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             max(1, 2, default=0)
 
+        # Test iterables that can only be looped once #510
+        self.assertEqual(min(x for x in [5]), 5)
+        self.assertEqual(max(x for x in [5, 4, 3]), 5)
+
     def test_next(self):
         it = iter(range(2))
         self.assertEqual(next(it), 0)

--- a/tests/test_future/test_builtins.py
+++ b/tests/test_future/test_builtins.py
@@ -1105,6 +1105,7 @@ class BuiltinTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             max(1, 2, default=0)
         self.assertEqual(max([], default=0), 0)
+        self.assertIs(max([], default=None), None)
 
     def test_min(self):
         self.assertEqual(min('123123'), '1')
@@ -1150,6 +1151,7 @@ class BuiltinTest(unittest.TestCase):
                          sorted(data, key=f)[0])
         self.assertEqual(min([], default=5), 5)
         self.assertEqual(min([], default=0), 0)
+        self.assertIs(min([], default=None), None)
         with self.assertRaises(TypeError):
             max(None, default=5)
         with self.assertRaises(TypeError):


### PR DESCRIPTION
I allowed a few fixes to creep into this PR, I can separate them out if desired. This PR addresses:
- There is an issue with the min/max functions consuming the first argument of iterators that cannot be looped over more than once. #510 
- The new min/max functions did not allow `None` as a default.
- Aligned the error message when an empty sequence was passed to the new min/max functions to be the same as the builtin min/max error message.