### PR TITLE
Use BaseException in raise_()

### DIFF
--- a/src/future/utils/__init__.py
+++ b/src/future/utils/__init__.py
@@ -408,17 +408,17 @@ if PY3:
         allows re-raising exceptions with the cls value and traceback on
         Python 2 and 3.
         """
-        if isinstance(tp, Exception):
+        if isinstance(tp, BaseException):
             # If the first object is an instance, the type of the exception
             # is the class of the instance, the instance itself is the value,
             # and the second object must be None.
             if value is not None:
                 raise TypeError("instance exception may not have a separate value")
             exc = tp
-        elif isinstance(tp, type) and not issubclass(tp, Exception):
+        elif isinstance(tp, type) and not issubclass(tp, BaseException):
             # If the first object is a class, it becomes the type of the
             # exception.
-            raise TypeError("class must derive from Exception")
+            raise TypeError("class must derive from BaseException, not %s" % tp.__name__)
         else:
             # The second object is used to determine the exception value: If it
             # is an instance of the class, the instance becomes the exception

--- a/tests/test_future/test_utils.py
+++ b/tests/test_future/test_utils.py
@@ -111,13 +111,13 @@ class TestUtils(unittest.TestCase):
         self.assertFalse(isbytes(self.s2))
 
     def test_raise_(self):
-        def valerror():
+        def valuerror():
             try:
                 raise ValueError("Apples!")
             except Exception as e:
                 raise_(e)
 
-        self.assertRaises(ValueError, valerror)
+        self.assertRaises(ValueError, valuerror)
 
         def with_value():
             raise_(IOError, "This is an error")
@@ -142,6 +142,17 @@ class TestUtils(unittest.TestCase):
             with_traceback()
         except IOError as e:
             self.assertEqual(str(e), "An error")
+
+        class Timeout(BaseException):
+            pass
+
+        self.assertRaises(Timeout, raise_, Timeout)
+        self.assertRaises(Timeout, raise_, Timeout())
+
+        if PY3:
+            self.assertRaisesRegexp(
+                TypeError, "class must derive from BaseException",
+                raise_, int)
 
     def test_raise_from_None(self):
         try:


### PR DESCRIPTION
In both Python 2 and 3, the Exception type is derived from
BaseException:

>  The base class for all built-in exceptions. It is not meant to be
>  directly inherited by user-defined classes (for that, use Exception).

In practice, some libraries provide exception types that do derive
directly from BaseException (such as `gevent.Timeout`), and this code
should recognize them as valid exception types.

As further evidence, Python 2 explicitly states that raised types must
be derived from BaseException:

>  exceptions must be old-style classes or derived from BaseException

Python 3 is more flexible here, which is why we provide a TypeError case
for non-BaseException-derived types. While I'm here, I made that message
a little more helpful by including the name of the incompatible type.

See also #512 