### PR TITLE
MIME guessing works in Python 3.8 in test_urllib2

### DIFF
--- a/tests/test_future/test_urllib2.py
+++ b/tests/test_future/test_urllib2.py
@@ -691,6 +691,10 @@ class HandlerTests(unittest.TestCase):
         h = NullFTPHandler(data)
         h.parent = MockOpener()
 
+        # MIME guessing works in Python 3.8!
+        guessed_mime = None
+        if sys.hexversion >= 0x03080000:
+            guessed_mime = "image/gif"
         for url, host, port, user, passwd, type_, dirs, filename, mimetype in [
             ("ftp://localhost/foo/bar/baz.html",
              "localhost", ftplib.FTP_PORT, "", "", "I",
@@ -709,7 +713,7 @@ class HandlerTests(unittest.TestCase):
              ["foo", "bar"], "", None),
             ("ftp://localhost/baz.gif;type=a",
              "localhost", ftplib.FTP_PORT, "", "", "A",
-             [], "baz.gif", None),  # XXX really this should guess image/gif
+             [], "baz.gif", guessed_mime),
             ]:
             req = Request(url)
             req.timeout = None


### PR DESCRIPTION
To continue to support other versions of Python, use sys.hexversion to
check if we're using 3.8 and set the MIME type appropriately.

Fixes #508