### PR TITLE
use object.setattr to bypass check for immutable objects

### DIFF
--- a/src/future/utils/__init__.py
+++ b/src/future/utils/__init__.py
@@ -473,7 +473,7 @@ else:
             e.__suppress_context__ = True
         elif isinstance(cause, BaseException):
             e.__cause__ = cause
-            e.__cause__.__traceback__ = sys.exc_info()[2]
+            object.__setattr__(e.__cause__,  '__traceback__', sys.exc_info()[2])
             e.__suppress_context__ = True
         else:
             raise TypeError("exception causes must derive from BaseException")


### PR DESCRIPTION
Using object.setattr will bypass the setattr check in the class of the exception, and execute the setattr on the base class. This will prevent this from throwing TypeErrors when exceptions are from immutable classes.