### PR TITLE
Sort before comparing dicts in TestChainMap

### DIFF
--- a/tests/test_future/test_backports.py
+++ b/tests/test_future/test_backports.py
@@ -87,7 +87,8 @@ class TestChainMap(unittest.TestCase):
         d['b'] = 20
         d['c'] = 30
         self.assertEqual(d.maps, [{'b':20, 'c':30}, {'a':1, 'b':2}])  # check internal state
-        self.assertEqual(d.items(), dict(a=1, b=20, c=30).items())    # check items/iter/getitem
+        self.assertEqual(sorted(d.items()),
+                         sorted(dict(a=1, b=20, c=30).items()))       # check items/iter/getitem
         self.assertEqual(len(d), 3)                                   # check len
         for key in 'abc':                                             # check contains
             self.assertIn(key, d)
@@ -96,7 +97,8 @@ class TestChainMap(unittest.TestCase):
 
         del d['b']                                                    # unmask a value
         self.assertEqual(d.maps, [{'c':30}, {'a':1, 'b':2}])          # check internal state
-        self.assertEqual(d.items(), dict(a=1, b=2, c=30).items())     # check items/iter/getitem
+        self.assertEqual(sorted(d.items()),
+                         sorted(dict(a=1, b=2, c=30).items()))        # check items/iter/getitem
         self.assertEqual(len(d), 3)                                   # check len
         for key in 'abc':                                             # check contains
             self.assertIn(key, d)


### PR DESCRIPTION
Sort the results of items() of a dict before comparing them.  PyPy
apparently does not produce consistent ordering on .items().

Fixes one of the failures from bug #530