### PR TITLE
Handling of __next__ and next by future.utils.get_next was reversed

### DIFF
--- a/src/future/utils/__init__.py
+++ b/src/future/utils/__init__.py
@@ -527,9 +527,9 @@ def implements_iterator(cls):
         return cls
 
 if PY3:
-    get_next = lambda x: x.next
-else:
     get_next = lambda x: x.__next__
+else:
+    get_next = lambda x: x.next
 
 
 def encode_filename(filename):


### PR DESCRIPTION
I assume nobody is using future.utils.get_next, because the builtin next() function exists from Python 2.6 on and meets most needs, and because nobody has noticed this before. Fixing in case it saves anyone confusion in future.