### PR TITLE
Add __subclasscheck__ for past.types.basestring

### DIFF
--- a/src/past/types/basestring.py
+++ b/src/past/types/basestring.py
@@ -25,9 +25,8 @@ class BaseBaseString(type):
     def __instancecheck__(cls, instance):
         return isinstance(instance, (bytes, str))
 
-    def __subclasshook__(cls, thing):
-        # TODO: What should go here?
-        raise NotImplemented
+    def __subclasscheck__(cls, subclass):
+        return super(BaseBaseString, cls).__subclasscheck__(subclass) or issubclass(subclass, (bytes, str))
 
 
 class basestring(with_metaclass(BaseBaseString)):

--- a/tests/test_past/test_basestring.py
+++ b/tests/test_past/test_basestring.py
@@ -19,6 +19,25 @@ class TestBaseString(unittest.TestCase):
         s2 = oldstr(b'abc')
         self.assertTrue(isinstance(s2, basestring))
 
+    def test_issubclass(self):
+        self.assertTrue(issubclass(str, basestring))
+        self.assertTrue(issubclass(bytes, basestring))
+        self.assertTrue(issubclass(basestring, basestring))
+        self.assertFalse(issubclass(int, basestring))
+        self.assertFalse(issubclass(list, basestring))
+        self.assertTrue(issubclass(basestring, object))
+
+        class CustomString(basestring):
+            pass
+        class NotString(object):
+            pass
+        class OldStyleClass:
+            pass
+        self.assertTrue(issubclass(CustomString, basestring))
+        self.assertFalse(issubclass(NotString, basestring))
+        self.assertFalse(issubclass(OldStyleClass, basestring))
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Previously `__subclasscheck__` was not implemented which lead to inconsistencies between `isinstance` and `issubclass` (i.e. `isinstance("a string", basestring)` is true, but `issubclass(str, basestring)` was false) This commit fixes this incorrect behavior.