### PR TITLE
Added r""" to the docstring to avoid warnings in python3

### DIFF
--- a/src/past/types/oldstr.py
+++ b/src/past/types/oldstr.py
@@ -20,7 +20,7 @@ class BaseOldStr(type):
 
 
 def unescape(s):
-    """
+    r"""
     Interprets strings with escape sequences
 
     Example:


### PR DESCRIPTION
Added r""" to the docstring to avoid warnings in python3

Warning example:
DeprecationWarning: invalid escape sequence \d