### PR TITLE
Support NumPy's specialized int types in builtins.round

### DIFF
--- a/src/future/builtins/newround.py
+++ b/src/future/builtins/newround.py
@@ -32,10 +32,10 @@ def newround(number, ndigits=None):
 
     exponent = Decimal('10') ** (-ndigits)
 
-    if PYPY:
-        # Work around issue #24: round() breaks on PyPy with NumPy's types
-        if 'numpy' in repr(type(number)):
-            number = float(number)
+    # Work around issue #24: round() breaks on PyPy with NumPy's types
+    # Also breaks on CPython with NumPy's specialized int types like uint64
+    if 'numpy' in repr(type(number)):
+        number = float(number)
 
     if isinstance(number, Decimal):
         d = number


### PR DESCRIPTION
Original workaround only impacted PyPy. I encountered the issue on CPython as well with NumPy's specialized int types like uint64.
