### PR TITLE
Add docs building to tox.ini

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+## Build documentation locally
+
+Using tox:
+```shell
+$ tox -e docs
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,6 @@
 
 from __future__ import absolute_import, print_function
 import sys, os
-from future import __version__
 import sphinx_bootstrap_theme
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,py36,py37
+envlist =
+    py{26,27,33,34,35,36,37},
+    docs
 
 [testenv]
 deps =
@@ -7,3 +9,9 @@ deps =
     unittest2
     py26: importlib
 commands = pytest {posargs}
+
+[testenv:docs]
+deps =
+    sphinx
+    sphinx_bootstrap_theme
+commands = sphinx-build docs build


### PR DESCRIPTION
Relate #511

```shell
$ tox -e docs

build succeeded, 16 warnings.

The HTML pages are in build.
__________________________________________________________________ summary ___________________________________________________________________
  docs: commands succeeded
  congratulations :)

```

Locally:

![image](https://user-images.githubusercontent.com/1016390/84557665-9914d880-ad5f-11ea-94ee-34da33548c58.png)

What's in public:
https://python-future.org/whatsnew.html

![image](https://user-images.githubusercontent.com/1016390/84557672-a8942180-ad5f-11ea-9094-73fccae91692.png)

