### PR TITLE
Bugfix with undefined children_hooks when package is None

### DIFF
--- a/src/libfuturize/fixer_util.py
+++ b/src/libfuturize/fixer_util.py
@@ -390,6 +390,7 @@ def touch_import_top(package, name_to_import, node):
                 break
         insert_pos = idx
 
+    children_hooks = []
     if package is None:
         import_ = Node(syms.import_name, [
             Leaf(token.NAME, u"import"),
@@ -413,8 +414,6 @@ def touch_import_top(package, name_to_import, node):
                                  ]
                                 )
             children_hooks = [install_hooks, Newline()]
-        else:
-            children_hooks = []
 
         # FromImport(package, [Leaf(token.NAME, name_to_import, prefix=u" ")])
 


### PR DESCRIPTION
Fix the code path in `touch_import_top()` where `package` is `None` (e.g. `import six` instead of `from six import string_types`). Fixed a minor bug in this code path, so that a custom fixer can use it.
(`touch_import_top()` is always called with a package within the futurize codebase.)