### PR TITLE
Add PY37_PLUS, PY38_PLUS, and PY39_PLUS

### DIFF
--- a/src/future/utils/__init__.py
+++ b/src/future/utils/__init__.py
@@ -61,6 +61,9 @@ PY3 = sys.version_info[0] >= 3
 PY34_PLUS = sys.version_info[0:2] >= (3, 4)
 PY35_PLUS = sys.version_info[0:2] >= (3, 5)
 PY36_PLUS = sys.version_info[0:2] >= (3, 6)
+PY37_PLUS = sys.version_info[0:2] >= (3, 7)
+PY38_PLUS = sys.version_info[0:2] >= (3, 8)
+PY39_PLUS = sys.version_info[0:2] >= (3, 9)
 PY2 = sys.version_info[0] == 2
 PY26 = sys.version_info[0:2] == (2, 6)
 PY27 = sys.version_info[0:2] == (2, 7)


### PR DESCRIPTION
This extends the set of existing PY3?_PLUS constants to include recent
Python 3.x releases.