### PR TITLE
Add docs requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,12 @@
 Overview: Easy, clean, reliable Python 2/3 compatibility
 ========================================================
 
+.. image:: https://travis-ci.org/PythonCharmers/python-future.svg?branch=master
+    :target: https://travis-ci.org/PythonCharmers/python-future
+
+.. image:: https://readthedocs.org/projects/python-future/badge/?version=latest
+    :target: https://python-future.readthedocs.io/en/latest/?badge=latest
+
 ``python-future`` is the missing compatibility layer between Python 2 and
 Python 3. It allows you to use a single, clean Python 3.x-compatible
 codebase to support both Python 2 and Python 3 with minimal overhead.
@@ -21,9 +27,6 @@ are `Mezzanine <http://mezzanine.jupo.org/>`_ and `ObsPy
 
 Features
 --------
-
-.. image:: https://travis-ci.org/PythonCharmers/python-future.svg?branch=master
-       :target: https://travis-ci.org/PythonCharmers/python-future
 
 -   ``future.builtins`` package (also available as ``builtins`` on Py2) provides
     backports and remappings for 20 builtins with different semantics on Py3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx==3.2.1
+sphinx_bootstrap_theme==0.7.1

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,5 @@ commands = pytest {posargs}
 
 [testenv:docs]
 deps =
-    sphinx
-    sphinx_bootstrap_theme
+    -rdocs/requirements.txt
 commands = sphinx-build docs build


### PR DESCRIPTION
RTD log:
```
Running Sphinx v1.8.5

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/python-future/envs/stable/lib/python3.7/site-packages/sphinx/config.py", line 368, in eval_config_file
    execfile_(filename, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/python-future/envs/stable/lib/python3.7/site-packages/sphinx/util/pycompat.py", line 150, in execfile_
    exec_(code, _globals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/python-future/checkouts/stable/docs/conf.py", line 17, in <module>
    import sphinx_bootstrap_theme
ModuleNotFoundError: No module named 'sphinx_bootstrap_theme'
```

Add doc requirements according to:
https://docs.readthedocs.io/en/stable/guides/specifying-dependencies.html