### PR TITLE
Fix removed stdlib modules breaking install_aliases()

### DIFF
--- a/src/future/moves/subprocess.py
+++ b/src/future/moves/subprocess.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
-from future.utils import PY2, PY26
+from future.utils import PY2, PY26, PY27
 
 from subprocess import *
 
-if PY2:
+if PY2 and not PY27:
     __future_module__ = True
     from commands import getoutput, getstatusoutput
 

--- a/src/future/standard_library/__init__.py
+++ b/src/future/standard_library/__init__.py
@@ -77,7 +77,7 @@ _handler.setFormatter(_formatter)
 flog.addHandler(_handler)
 flog.setLevel(logging.WARN)
 
-from future.utils import PY2, PY3
+from future.utils import PY2, PY27, PY3
 
 # The modules that are defined under the same names on Py3 but with
 # different contents in a significant way (e.g. submodules) are:
@@ -190,8 +190,6 @@ MOVES = [('collections', 'UserList', 'UserList', 'UserList'),
          ('re', 'ASCII','stat', 'ST_MODE'),
          ('base64', 'encodebytes','base64', 'encodestring'),
          ('base64', 'decodebytes','base64', 'decodestring'),
-         ('subprocess', 'getoutput', 'commands', 'getoutput'),
-         ('subprocess', 'getstatusoutput', 'commands', 'getstatusoutput'),
          ('subprocess', 'check_output', 'future.backports.misc', 'check_output'),
          ('math', 'ceil', 'future.backports.misc', 'ceil'),
          ('collections', 'OrderedDict', 'future.backports.misc', 'OrderedDict'),
@@ -208,6 +206,12 @@ MOVES = [('collections', 'UserList', 'UserList', 'UserList'),
 #          ('urllib', 'response', 'future.moves.urllib', 'response'),
 #          ('urllib', 'robotparser', 'future.moves.urllib', 'robotparser'),
         ]
+
+if PY2 and not PY27:
+    MOVES += [
+        ('subprocess', 'getoutput', 'commands', 'getoutput'),
+        ('subprocess', 'getstatusoutput', 'commands', 'getstatusoutput'),
+    ]
 
 
 # A minimal example of an import hook:


### PR DESCRIPTION
Fixes #174

Include subprocess.getoutput and subprocess.getstatusoutput aliases for commands module only on Python < 2.7. Otherwise, when calling standard_library.install_aliases(), a following error will occur:

    Traceback (most recent call last):
      File "mytest.py", line 9, in <module>
        standard_library.install_aliases()
      File "/usr/lib/python2.7/site-packages/future/standard_library/__init__.py", line 460, in install_aliases
        obj = getattr(oldmod, oldobjname)
    AttributeError: 'module' object has no attribute 'getoutput'