### PR TITLE
docs: fix simple typo, reqest -> request

### DIFF
--- a/tests/test_future/test_urllibnet.py
+++ b/tests/test_future/test_urllibnet.py
@@ -38,7 +38,7 @@ class URLTimeoutTest(unittest.TestCase):
 
 
 class urlopenNetworkTests(unittest.TestCase):
-    """Tests urllib.reqest.urlopen using the network.
+    """Tests urllib.request.urlopen using the network.
 
     These tests are not exhaustive.  Assuming that testing using files does a
     good job overall of some of the basic interface features.  There are no


### PR DESCRIPTION
There is a small typo in tests/test_future/test_urllibnet.py.

Should read `request` rather than `reqest`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md