### PR TITLE
Fix bug in super() with metaclasses

### DIFF
--- a/tests/test_future/test_super.py
+++ b/tests/test_future/test_super.py
@@ -170,6 +170,18 @@ class TestSuper(unittest.TestCase):
 
         self.assertEqual(Elite().walk(), 'Defused')
 
+    def test_metaclass(self):
+        class Meta(type):
+            def __init__(cls, name, bases, clsdict):
+                super().__init__(name, bases, clsdict)
+
+        try:
+            class Base(object):
+                __metaclass__ = Meta
+        except Exception as e:
+            self.fail('raised %s with a custom metaclass'
+                      % type(e).__name__)
+
 
 class TestSuperFromTestDescrDotPy(unittest.TestCase):
     """


### PR DESCRIPTION
Hi! First of all, thanks for this lib, it really makes dealing with legacy code much more bearable.

I got an error trying to call a metaclass with `super()` without arguments, and I've found it's searching the method's owner in the class' own mro. But the metaclass is not its superclass, so the owner is never found. This PR adds a fallback to search the owner in the metaclass mro and a test with the case at #267.

Regards,