### PR TITLE
Fix newint bool in py3

### DIFF
--- a/src/future/types/newint.py
+++ b/src/future/types/newint.py
@@ -284,6 +284,9 @@ class newint(with_metaclass(BaseNewInt, long)):
         """
         So subclasses can override this, Py3-style
         """
+        if PY3:
+            return super(newint, self).__bool__()
+
         return super(newint, self).__nonzero__()
 
     def __native__(self):


### PR DESCRIPTION
I got an error when I use `newint.__bool__` in Python 3.
`AttributeError: 'super' object has no attribute '__nonzero__'`

And I found `newint.__bool__` will super `int.__nonzero__`, but there's no `int.__nonzero__` in Python 3.
So I add a condition to check if it is Python 3. If so, super `int.__bool__` instead of `int.__nonzero__`.