### PR TITLE
Fix bug in fix_raise.py fixer

### DIFF
--- a/src/libfuturize/fixes/fix_raise.py
+++ b/src/libfuturize/fixes/fix_raise.py
@@ -94,7 +94,7 @@ class FixRaise(fixer_base.BaseFix):
                 args = [exc, Comma(), val]
                 if tb is not None:
                     args += [Comma(), tb]
-                return Call(Name(u"raise_"), args)
+                return Call(Name(u"raise_"), args, prefix=node.prefix)
 
         if tb is not None:
             tb.prefix = ""

--- a/tests/test_future/test_libfuturize_fixers.py
+++ b/tests/test_future/test_libfuturize_fixers.py
@@ -767,6 +767,20 @@ class Test_raise(FixerTestCase):
         raise_(E, Func(arg1, arg2, arg3), tb) # foo"""
         self.check(b, a)
 
+    def test_unknown_value_with_indent(self):
+        b = """
+        while True:
+            print()  # another expression in the same block triggers different parsing
+            raise E, V
+        """
+        a = """
+        from future.utils import raise_
+        while True:
+            print()  # another expression in the same block triggers different parsing
+            raise_(E, V)
+        """
+        self.check(b, a)
+
     # These should produce a warning
 
     def test_string_exc(self):


### PR DESCRIPTION
The replacement node for the fix of a raise statement with an unknown
value should inherit the prefix of the source node.