### PR TITLE
Fix bug in fix_print.py fixer

### DIFF
--- a/src/libfuturize/fixes/fix_print.py
+++ b/src/libfuturize/fixes/fix_print.py
@@ -57,6 +57,16 @@ class FixPrint(fixer_base.BaseFix):
         if args and args[-1] == Comma():
             args = args[:-1]
             end = " "
+
+            # try to determine if the string ends in a non-space whitespace character, in which
+            # case there should be no space at the end of the conversion
+            string_leaves = [leaf for leaf in args[-1].leaves() if leaf.type == token.STRING]
+            if (
+                string_leaves
+                and string_leaves[-1].value[0] != "r"  # "raw" string
+                and string_leaves[-1].value[-3:-1] in (r"\t", r"\n", r"\r")
+            ):
+                end = ""
         if args and args[0] == pytree.Leaf(token.RIGHTSHIFT, u">>"):
             assert len(args) >= 2
             file = args[1].clone()

--- a/tests/test_future/test_libfuturize_fixers.py
+++ b/tests/test_future/test_libfuturize_fixers.py
@@ -307,6 +307,37 @@ class Test_print(FixerTestCase):
         a = """print(1, end=' ')"""
         self.check(b, a)
 
+    def test_trailing_comma_4(self):
+        b = """print "a ","""
+        a = """print("a ", end=' ')"""
+        self.check(b, a)
+
+    def test_trailing_comma_5(self):
+        b = r"""print "b\t","""
+        a = r"""print("b\t", end='')"""
+        self.check(b, a)
+
+    def test_trailing_comma_6(self):
+        b = r"""print "c\n","""
+        a = r"""print("c\n", end='')"""
+        self.check(b, a)
+
+    def test_trailing_comma_7(self):
+        b = r"""print "d\r","""
+        a = r"""print("d\r", end='')"""
+        self.check(b, a)
+
+    def test_trailing_comma_8(self):
+        b = r"""print "%s\n" % (1,),"""
+        a = r"""print("%s\n" % (1,), end='')"""
+        self.check(b, a)
+
+
+    def test_trailing_comma_9(self):
+        b = r"""print r"e\n","""
+        a = r"""print(r"e\n", end=' ')"""
+        self.check(b, a)
+
     # >> stuff
 
     def test_vargs_without_trailing_comma(self):


### PR DESCRIPTION
When the print ends with a non-space whitespace character, an extra
space character should not be printed at the end.

From the python2 documentation:
> A space is written before each object is (converted and) written, unless the output system believes it is positioned at the beginning of a line. This is the case (1) when no characters have yet been written to standard output, (2) when the last character written to standard output is a whitespace character except `' '`, or (3) when the last write operation on standard output was not a `print` statement.

The changes here don't do this perfectly (e.g. when a printed string variable ends with a tab), but capture the common case of when a literal string which ends in a tab or line feed is printed with a trailing comma, like `print "something\t",`.

Addresses (at least partially) #473.