### PR TITLE
modified fix_unpacking.py for use in both python versions 2/3

### DIFF
--- a/src/libpasteurize/fixes/fix_unpacking.py
+++ b/src/libpasteurize/fixes/fix_unpacking.py
@@ -20,11 +20,9 @@ def assignment_source(num_pre, num_post, LISTNAME, ITERNAME):
     children = []
     try:
         pre = unicode(num_pre)
-    except NameError:
-        pre = str(num_pre)
-    try:
         post = unicode(num_post)
     except NameError:
+        pre = str(num_pre)
         post = str(num_post)
     # This code builds the assignment source from lib2to3 tree primitives.
     # It's not very readable, but it seems like the most correct way to do it.

--- a/src/libpasteurize/fixes/fix_unpacking.py
+++ b/src/libpasteurize/fixes/fix_unpacking.py
@@ -18,8 +18,14 @@ def assignment_source(num_pre, num_post, LISTNAME, ITERNAME):
     Returns a source fit for Assign() from fixer_util
     """
     children = []
-    pre = unicode(num_pre)
-    post = unicode(num_post)
+    try:
+        pre = unicode(num_pre)
+    except NameError:
+        pre = str(num_pre)
+    try:
+        post = unicode(num_post)
+    except NameError:
+        post = str(num_post)
     # This code builds the assignment source from lib2to3 tree primitives.
     # It's not very readable, but it seems like the most correct way to do it.
     if num_pre > 0:


### PR DESCRIPTION
Changed fix_unpacking.py to use:
- "unicode" function for python2
- "str" function for python3

For me, this fixed the issue referenced in https://github.com/PythonCharmers/python-future/issues/549
