### PR TITLE
future cannot install without setuptools

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx==3.2.1
 sphinx_bootstrap_theme==0.7.1
+setuptools==0.18.2


### PR DESCRIPTION
when setuptools is not installed, future fails to install using pip. This will fix that bug.
Signed-off-by: matthew <stidmatt@gmail.com>