### PR TITLE
Add Security Policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are applied only to the latest release.
+
+## Reporting a Vulnerability
+
+If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.** This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
+
+Please disclose it at [security advisory](https://github.com/PythonCharmers/python-future/security/advisories/new).
+
+This project is maintained by a team of volunteers on a reasonable-effort basis. As such, please give us at least 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Resolves https://github.com/PythonCharmers/python-future/issues/620

Here's a Security Policy suggestion.

The link for reporting vulnerabilities uses GitHub's Security Advisories [report vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) feature, which is in beta. You would need to enable the feature in the repo for it to work.

##### How to enable private vulnerability reports

1. Open the repo's settings
2. Click on Code security & analysis
3. Click "Enable" for "Private vulnerability reporting (Beta)"

I've tried to keep the timelines for confirming vulnerability reports and fixing vulnerabilities as open as possible.

Let me know what do you think and if this seems reasonable for maintenance.