### PR TITLE
WIP Python 3.12 support for removal of imp module

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@ set -xuo pipefail
 
 DOCKER_IMAGE=jmadler/python-future-builder
 # XXX: TODO: Perhaps this version shouldn't be hardcoded
-version=0.18.3
+version=0.18.4
 
 docker build . -t $DOCKER_IMAGE
 docker push $DOCKER_IMAGE:latest

--- a/docs/whatsnew.rst
+++ b/docs/whatsnew.rst
@@ -3,6 +3,12 @@
 What's New
 **********
 
+What's new in version 0.18.4 (2023-10-10)
+=========================================
+This is a minor bug-fix release containing a number of fixes:
+
+- Fix for Python 3.12's removal of the imp module
+
 What's new in version 0.18.3 (2023-01-13)
 =========================================
 This is a minor bug-fix release containing a number of fixes:

--- a/src/future/__init__.py
+++ b/src/future/__init__.py
@@ -87,7 +87,7 @@ __license__ = 'MIT'
 __copyright__ = 'Copyright 2013-2019 Python Charmers Pty Ltd'
 __ver_major__ = 0
 __ver_minor__ = 18
-__ver_patch__ = 3
+__ver_patch__ = 4
 __ver_sub__ = ''
 __version__ = "%d.%d.%d%s" % (__ver_major__, __ver_minor__,
                               __ver_patch__, __ver_sub__)

--- a/src/future/backports/test/support.py
+++ b/src/future/backports/test/support.py
@@ -28,7 +28,10 @@ import importlib
 # import collections.abc    # not present on Py2.7
 import re
 import subprocess
-import imp
+try:
+    from imp import cache_from_source
+except ImportError:
+    from importlib.util import cache_from_source
 import time
 try:
     import sysconfig
@@ -351,7 +354,7 @@ def make_legacy_pyc(source):
         does not need to exist, however the PEP 3147 pyc file must exist.
     :return: The file system path to the legacy pyc file.
     """
-    pyc_file = imp.cache_from_source(source)
+    pyc_file = cache_from_source(source)
     up_one = os.path.dirname(os.path.abspath(source))
     legacy_pyc = os.path.join(up_one, source + ('c' if __debug__ else 'o'))
     os.rename(pyc_file, legacy_pyc)
@@ -370,8 +373,8 @@ def forget(modname):
         # combinations of PEP 3147 and legacy pyc and pyo files.
         unlink(source + 'c')
         unlink(source + 'o')
-        unlink(imp.cache_from_source(source, debug_override=True))
-        unlink(imp.cache_from_source(source, debug_override=False))
+        unlink(cache_from_source(source, debug_override=True))
+        unlink(cache_from_source(source, debug_override=False))
 
 # On some platforms, should not run gui test even if it is allowed
 # in `use_resources'.

--- a/src/future/standard_library/__init__.py
+++ b/src/future/standard_library/__init__.py
@@ -62,7 +62,10 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 import logging
-import imp
+try:
+    import importlib
+except ImportError:
+    import imp
 import contextlib
 import types
 import copy
@@ -297,8 +300,11 @@ class RenameImport(object):
                 flog.debug('What to do here?')
 
         name = bits[0]
-        module_info = imp.find_module(name, path)
-        return imp.load_module(name, *module_info)
+        try:
+            module_info = imp.find_module(name, path)
+            return imp.load_module(name, *module_info)
+        except AttributeError:
+            return importlib.import_module(name, path)
 
 
 class hooks(object):

--- a/src/past/translation/__init__.py
+++ b/src/past/translation/__init__.py
@@ -32,7 +32,10 @@ Author: Ed Schofield.
 Inspired by and based on ``uprefix`` by Vinay M. Sajip.
 """
 
-import imp
+try:
+    import imp
+except ImportError:
+    import importlib
 import logging
 import marshal
 import os

--- a/tests/test_future/test_standard_library.py
+++ b/tests/test_future/test_standard_library.py
@@ -447,9 +447,14 @@ class TestStandardLibraryReorganization(CodeHandler):
         """
         reload has been moved to the imp module
         """
-        import imp
-        imp.reload(imp)
-        self.assertTrue(True)
+        try:
+            import imp
+            imp.reload(imp)
+            self.assertTrue(True)
+        except ImportError:
+            import importlib
+            importlib.reload(importlib)
+            self.assertTrue(True)
 
     def test_install_aliases(self):
         """


### PR DESCRIPTION
Issue https://github.com/PythonCharmers/python-future/issues/625

Test suite is broken.

src/past/translation/__init__.py is broken (I only replaced the import statement).


```
======================================================================================= short test summary info ========================================================================================
FAILED tests/test_future/test_backports.py::TestOrderedDict::test_repr - AssertionError: "OrderedDict({'c': 1, 'b': 2, 'a': 3, 'd': 4, 'e': 5, 'f': 6})" != "OrderedDict([('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)])"
FAILED tests/test_future/test_backports.py::TestOrderedDict::test_repr_recursive - AssertionError: "OrderedDict({'a': None, 'b': None, 'c': None, 'x': ...})" != "OrderedDict([('a', None), ('b', None), ('c', None), ('x', ...)])"
FAILED tests/test_future/test_builtins.py::BuiltinTest::test_compile - SyntaxError: source code string cannot contain null bytes
FAILED tests/test_future/test_builtins.py::BuiltinTest::test_pow - AssertionError: (<class 'TypeError'>, <class 'ValueError'>) not raised by pow
FAILED tests/test_future/test_isinstance.py::TestIsInstanceIsSubclass::test_isinstance_recursion_limit - AssertionError: RuntimeError not raised by blowstack
FAILED tests/test_future/test_isinstance.py::TestIsInstanceIsSubclass::test_subclass_recursion_limit - AssertionError: RuntimeError not raised by blowstack
FAILED tests/test_future/test_standard_library.py::TestStandardLibraryReorganization::test_underscore_prefixed_modules - ImportError: This package should not be accessible on Python 3. Either you are trying to run from the python-future src folder or your installation of python-future is corrupted.
FAILED tests/test_future/test_standard_library.py::TestFutureMoves::test_future_moves - ImportError: This package should not be accessible on Python 3. Either you are trying to run from the python-future src folder or your installation of python-future is corrupted.
FAILED tests/test_future/test_urllib2.py::HandlerTests::test_ftp - AssertionError: None != 'image/gif'
FAILED tests/test_future/test_urllib2.py::test_main - future.backports.test.support.TestFailed: Traceback (most recent call last):
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_FileTests::test_close - AttributeError: module 'future.moves.test.support' has no attribute 'TESTFN'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_FileTests::test_fileno - AttributeError: module 'future.moves.test.support' has no attribute 'TESTFN'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_FileTests::test_getcode - AttributeError: module 'future.moves.test.support' has no attribute 'TESTFN'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_FileTests::test_geturl - AttributeError: module 'future.moves.test.support' has no attribute 'TESTFN'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_FileTests::test_info - AttributeError: module 'future.moves.test.support' has no attribute 'TESTFN'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_FileTests::test_interface - AttributeError: module 'future.moves.test.support' has no attribute 'TESTFN'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_FileTests::test_iter - AttributeError: module 'future.moves.test.support' has no attribute 'TESTFN'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_FileTests::test_read - AttributeError: module 'future.moves.test.support' has no attribute 'TESTFN'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_FileTests::test_readline - AttributeError: module 'future.moves.test.support' has no attribute 'TESTFN'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_FileTests::test_readlines - AttributeError: module 'future.moves.test.support' has no attribute 'TESTFN'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_FileTests::test_relativelocalfile - AttributeError: module 'future.moves.test.support' has no attribute 'TESTFN'
FAILED tests/test_future/test_urllib_toplevel.py::ProxyTests::test_getproxies_environment_keep_no_proxies - AttributeError: module 'future.moves.test.support' has no attribute 'EnvironmentVarGuard'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_HttpTests::test_URLopener_deprecation - AttributeError: module 'future.moves.test.support' has no attribute 'check_warnings'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_HttpTests::test_empty_socket - AttributeError: module 'future.moves.test.support' has no attribute 'check_warnings'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_HttpTests::test_file_notexists - AttributeError: module 'future.moves.test.support' has no attribute 'check_warnings'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_HttpTests::test_ftp_nohost - AttributeError: module 'future.moves.test.support' has no attribute 'check_warnings'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_HttpTests::test_ftp_nonexisting - AttributeError: module 'future.moves.test.support' has no attribute 'check_warnings'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_HttpTests::test_missing_localfile - AttributeError: module 'future.moves.test.support' has no attribute 'check_warnings'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_HttpTests::test_read_0_9 - AttributeError: module 'future.moves.test.support' has no attribute 'check_warnings'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_HttpTests::test_read_1_0 - AttributeError: module 'future.moves.test.support' has no attribute 'check_warnings'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_HttpTests::test_read_1_1 - AttributeError: module 'future.moves.test.support' has no attribute 'check_warnings'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_HttpTests::test_read_bogus - AttributeError: module 'future.moves.test.support' has no attribute 'check_warnings'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_HttpTests::test_userpass_inurl - AttributeError: module 'future.moves.test.support' has no attribute 'check_warnings'
FAILED tests/test_future/test_urllib_toplevel.py::urlopen_HttpTests::test_userpass_inurl_w_spaces - AttributeError: module 'future.moves.test.support' has no attribute 'check_warnings'
FAILED tests/test_future/test_urllib_toplevel.py::urlretrieve_FileTests::test_basic - AttributeError: module 'future.moves.test.support' has no attribute 'TESTFN'
FAILED tests/test_future/test_urllib_toplevel.py::urlretrieve_FileTests::test_copy - AttributeError: module 'future.moves.test.support' has no attribute 'TESTFN'
FAILED tests/test_future/test_urllib_toplevel.py::urlretrieve_FileTests::test_reporthook - AttributeError: module 'future.moves.test.support' has no attribute 'TESTFN'
FAILED tests/test_future/test_urllib_toplevel.py::urlretrieve_FileTests::test_reporthook_0_bytes - AttributeError: module 'future.moves.test.support' has no attribute 'TESTFN'
FAILED tests/test_future/test_urllib_toplevel.py::urlretrieve_FileTests::test_reporthook_5_bytes - AttributeError: module 'future.moves.test.support' has no attribute 'TESTFN'
FAILED tests/test_future/test_urllib_toplevel.py::urlretrieve_FileTests::test_reporthook_8193_bytes - AttributeError: module 'future.moves.test.support' has no attribute 'TESTFN'
FAILED tests/test_future/test_urllib_toplevel.py::UnquotingTests::test_unquoting - AttributeError: module 'future.moves.test.support' has no attribute 'check_warnings'
FAILED tests/test_future/test_urllib_toplevel.py::URLopener_Tests::test_quoted_open - AttributeError: module 'future.moves.test.support' has no attribute 'check_warnings'
FAILED tests/test_future/test_utils.py::TestUtils::test_raise_ - AttributeError: 'TestUtils' object has no attribute 'assertRaisesRegexp'. Did you mean: 'assertRaisesRegex'?
FAILED tests/test_past/test_translation.py::TestTranslate::test_div - AssertionError: 1.5 != 1
FAILED tests/test_past/test_translation.py::TestTranslate::test_exception_syntax - AttributeError: 'NoneType' object has no attribute 'value'
FAILED tests/test_past/test_translation.py::TestTranslate::test_exec_statement - AttributeError: 'NoneType' object has no attribute 'x'
FAILED tests/test_past/test_translation.py::TestTranslate::test_old_builtin_functions - NameError: name 'xrange' is not defined
FAILED tests/test_past/test_translation.py::TestTranslate::test_print_statement - AttributeError: 'NoneType' object has no attribute 'finished'
FAILED tests/test_past/test_translation.py::TestTranslate::test_xrange - NameError: name 'xrange' is not defined
================================================================ 49 failed, 1010 passed, 37 skipped, 46 xfailed, 70 warnings in 23.56s =================================================================
```