### PR TITLE
Add Python 3.10 and 3.11 to the testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
           - python: "3.7"
           - python: "3.8"
           - python: "3.9"
+          - python: "3.10"
+          - python: "3.11"
+          - python: "3.12"
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           - python: "3.9"
           - python: "3.10"
           - python: "3.11"
-          - python: "3.12"
+          # - python: "3.12"
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
__DeprecationWarning:__
```
/usr/local/lib/python3.12/site-packages/libfuturize/fixer_util.py:11:
  DeprecationWarning: lib2to3 package is deprecated and may not be able to parse Python 3.10+
    from lib2to3.fixer_util import (FromImport, Newline, is_import,
```
---
On Python 3.12...
```
=================================== FAILURES ===================================
___________ TestIsInstanceIsSubclass.test_isinstance_recursion_limit ___________

self = <test_future.test_isinstance.TestIsInstanceIsSubclass testMethod=test_isinstance_recursion_limit>

    def test_isinstance_recursion_limit(self):
        # make sure that issubclass raises RuntimeError before the C stack is
        # blown
>       self.assertRaises(RuntimeError, blowstack, isinstance, '', str)
E       AssertionError: RuntimeError not raised by blowstack

tests/test_future/test_isinstance.py:275: AssertionError
____________ TestIsInstanceIsSubclass.test_subclass_recursion_limit ____________

self = <test_future.test_isinstance.TestIsInstanceIsSubclass testMethod=test_subclass_recursion_limit>

    def test_subclass_recursion_limit(self):
        # make sure that issubclass raises RuntimeError before the C stack is
        # blown
>       self.assertRaises(RuntimeError, blowstack, issubclass, str, str)
E       AssertionError: RuntimeError not raised by blowstack

tests/test_future/test_isinstance.py:270: AssertionError
```