### PR TITLE
PYTHONSAFEPATH compatible setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,11 @@ PACKAGE_DATA = {'': [
                 'tests': ['*.py'],
                 }
 
+# Python 3.11 onwards have a PYTHONSAFEPATH option that does not prepend the 
+# current directory sys.path; so ensure that it is there.
+root_dir = os.path.abspath(os.path.dirname(__file__))
+sys.path.insert(0, root_dir)
+
 import src.future
 VERSION = src.future.__version__
 DESCRIPTION = "Clean single-source support for Python 3 and 2"


### PR DESCRIPTION
Test Plan for Python 3.11+

Without this change:
```
% PYTHONSAFEPATH=true python3 setup.py bdist_wheel --python-tag=py311
Traceback (most recent call last):
  File "/Users/sidb/Workspaces/python-future/setup.py", line 81, in <module>
    import src.future
ModuleNotFoundError: No module named 'src'
```

With this change:
```
% PYTHONSAFEPATH=true python3 setup.py bdist_wheel --python-tag=py311
running bdist_wheel
...
```