### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/src/future/backports/email/_header_value_parser.py
+++ b/src/future/backports/email/_header_value_parser.py
@@ -659,8 +659,8 @@ class Comment(WhiteSpaceTokenList):
         if value.token_type == 'comment':
             return str(value)
         return str(value).replace('\\', '\\\\').replace(
-                                  '(', '\(').replace(
-                                  ')', '\)')
+                                  '(', '\\(').replace(
+                                  ')', '\\)')
 
     @property
     def content(self):
@@ -1346,15 +1346,15 @@ characters left in the string after the phrase is removed.
 
 _wsp_splitter = re.compile(r'([{}]+)'.format(''.join(WSP))).split
 _non_atom_end_matcher = re.compile(r"[^{}]+".format(
-    ''.join(ATOM_ENDS).replace('\\','\\\\').replace(']','\]'))).match
+    ''.join(ATOM_ENDS).replace('\\','\\\\').replace(']','\\]'))).match
 _non_printable_finder = re.compile(r"[\x00-\x20\x7F]").findall
 _non_token_end_matcher = re.compile(r"[^{}]+".format(
-    ''.join(TOKEN_ENDS).replace('\\','\\\\').replace(']','\]'))).match
+    ''.join(TOKEN_ENDS).replace('\\','\\\\').replace(']','\\]'))).match
 _non_attribute_end_matcher = re.compile(r"[^{}]+".format(
-    ''.join(ATTRIBUTE_ENDS).replace('\\','\\\\').replace(']','\]'))).match
+    ''.join(ATTRIBUTE_ENDS).replace('\\','\\\\').replace(']','\\]'))).match
 _non_extended_attribute_end_matcher = re.compile(r"[^{}]+".format(
     ''.join(EXTENDED_ATTRIBUTE_ENDS).replace(
-                                    '\\','\\\\').replace(']','\]'))).match
+                                    '\\','\\\\').replace(']','\\]'))).match
 
 def _validate_xtext(xtext):
     """If input token contains ASCII non-printables, register a defect."""
@@ -1538,7 +1538,7 @@ def get_unstructured(value):
     return unstructured
 
 def get_qp_ctext(value):
-    """ctext = <printable ascii except \ ( )>
+    """ctext = <printable ascii except \\ ( )>
 
     This is not the RFC ctext, since we are handling nested comments in comment
     and unquoting quoted-pairs here.  We allow anything except the '()'
@@ -1873,7 +1873,7 @@ def get_obs_local_part(value):
     return obs_local_part, value
 
 def get_dtext(value):
-    """ dtext = <printable ascii except \ [ ]> / obs-dtext
+    """ dtext = <printable ascii except \\ [ ]> / obs-dtext
         obs-dtext = obs-NO-WS-CTL / quoted-pair
 
     We allow anything except the excluded characters, but if we find any

--- a/src/future/backports/email/feedparser.py
+++ b/src/future/backports/email/feedparser.py
@@ -34,7 +34,7 @@ from future.backports.email._policybase import compat32
 
 NLCRE = re.compile('\r\n|\r|\n')
 NLCRE_bol = re.compile('(\r\n|\r|\n)')
-NLCRE_eol = re.compile('(\r\n|\r|\n)\Z')
+NLCRE_eol = re.compile(r'(\r\n|\r|\n)\Z')
 NLCRE_crack = re.compile('(\r\n|\r|\n)')
 # RFC 2822 $3.6.8 Optional fields.  ftext is %d33-57 / %d59-126, Any character
 # except controls, SP, and ":".

--- a/src/future/backports/email/utils.py
+++ b/src/future/backports/email/utils.py
@@ -65,7 +65,7 @@ escapesre = re.compile(r'[\\"]')
 # How to figure out if we are processing strings that come from a byte
 # source with undecodable characters.
 _has_surrogates = re.compile(
-    '([^\ud800-\udbff]|\A)[\udc00-\udfff]([^\udc00-\udfff]|\Z)').search
+    r'([^\ud800-\udbff]|\A)[\udc00-\udfff]([^\udc00-\udfff]|\Z)').search
 
 # How to deal with a string containing bytes before handing it to the
 # application through the 'normal' interface.

--- a/src/future/backports/html/parser.py
+++ b/src/future/backports/html/parser.py
@@ -28,7 +28,7 @@ charref = re.compile('&#(?:[0-9]+|[xX][0-9a-fA-F]+)[^0-9a-fA-F]')
 starttagopen = re.compile('<[a-zA-Z]')
 piclose = re.compile('>')
 commentclose = re.compile(r'--\s*>')
-tagfind = re.compile('([a-zA-Z][-.a-zA-Z0-9:_]*)(?:\s|/(?!>))*')
+tagfind = re.compile(r'([a-zA-Z][-.a-zA-Z0-9:_]*)(?:\s|/(?!>))*')
 # see http://www.w3.org/TR/html5/tokenization.html#tag-open-state
 # and http://www.w3.org/TR/html5/tokenization.html#tag-name-state
 tagfind_tolerant = re.compile('[a-zA-Z][^\t\n\r\f />\x00]*')
@@ -76,7 +76,7 @@ locatestarttagend_tolerant = re.compile(r"""
 endendtag = re.compile('>')
 # the HTML 5 spec, section 8.1.2.2, doesn't allow spaces between
 # </ and the tag name, so maybe this should be fixed
-endtagfind = re.compile('</\s*([a-zA-Z][-.a-zA-Z0-9:_]*)\s*>')
+endtagfind = re.compile(r'</\s*([a-zA-Z][-.a-zA-Z0-9:_]*)\s*>')
 
 
 class HTMLParseError(Exception):

--- a/src/future/backports/http/client.py
+++ b/src/future/backports/http/client.py
@@ -1,4 +1,4 @@
-"""HTTP/1.1 client library
+r"""HTTP/1.1 client library
 
 A backport of the Python 3.3 http/client.py module for python-future.
 

--- a/src/future/backports/http/cookiejar.py
+++ b/src/future/backports/http/cookiejar.py
@@ -209,7 +209,7 @@ def _str2time(day, mon, yr, hr, min, sec, tz):
 
 STRICT_DATE_RE = re.compile(
     r"^[SMTWF][a-z][a-z], (\d\d) ([JFMASOND][a-z][a-z]) "
-    "(\d\d\d\d) (\d\d):(\d\d):(\d\d) GMT$", re.ASCII)
+    r"(\d\d\d\d) (\d\d):(\d\d):(\d\d) GMT$", re.ASCII)
 WEEKDAY_RE = re.compile(
     r"^(?:Sun|Mon|Tue|Wed|Thu|Fri|Sat)[a-z]*,?\s*", re.I | re.ASCII)
 LOOSE_HTTP_DATE_RE = re.compile(
@@ -290,7 +290,7 @@ def http2time(text):
     return _str2time(day, mon, yr, hr, min, sec, tz)
 
 ISO_DATE_RE = re.compile(
-    """^
+    r"""^
     (\d{4})              # year
        [-\/]?
     (\d\d?)              # numerical month
@@ -426,7 +426,7 @@ def split_header_words(header_values):
                 pairs = []
             else:
                 # skip junk
-                non_junk, nr_junk_chars = re.subn("^[=\s;]*", "", text)
+                non_junk, nr_junk_chars = re.subn(r"^[=\s;]*", "", text)
                 assert nr_junk_chars > 0, (
                     "split_header_words bug: '%s', '%s', %s" %
                     (orig_text, text, pairs))

--- a/src/future/backports/test/support.py
+++ b/src/future/backports/test/support.py
@@ -1942,7 +1942,7 @@ def can_xattr():
                     os.setxattr(fp.fileno(), b"user.test", b"")
                     # Kernels < 2.6.39 don't respect setxattr flags.
                     kernel_version = platform.release()
-                    m = re.match("2.6.(\d{1,2})", kernel_version)
+                    m = re.match(r"2.6.(\d{1,2})", kernel_version)
                     can = m is None or int(m.group(1)) >= 39
                 except OSError:
                     can = False

--- a/src/future/backports/urllib/parse.py
+++ b/src/future/backports/urllib/parse.py
@@ -954,7 +954,7 @@ def splitquery(url):
     global _queryprog
     if _queryprog is None:
         import re
-        _queryprog = re.compile('^(.*)\?([^?]*)$')
+        _queryprog = re.compile(r'^(.*)\?([^?]*)$')
 
     match = _queryprog.match(url)
     if match: return match.group(1, 2)


### PR DESCRIPTION
When trying to run

```
python -m compileall -q <dir>
```

on this project (as the XBPS package manager does), a lot of `SyntaxWarning: invalid escape sequence` warnings are spewed:

```
./future/backports/email/_header_value_parser.py:662: SyntaxWarning: invalid escape sequence '\('
  '(', '\(').replace(
./future/backports/email/_header_value_parser.py:663: SyntaxWarning: invalid escape sequence '\)'
  ')', '\)')
./future/backports/email/_header_value_parser.py:1349: SyntaxWarning: invalid escape sequence '\]'
  ''.join(ATOM_ENDS).replace('\\','\\\\').replace(']','\]'))).match
./future/backports/email/_header_value_parser.py:1352: SyntaxWarning: invalid escape sequence '\]'
  ''.join(TOKEN_ENDS).replace('\\','\\\\').replace(']','\]'))).match
./future/backports/email/_header_value_parser.py:1354: SyntaxWarning: invalid escape sequence '\]'
  ''.join(ATTRIBUTE_ENDS).replace('\\','\\\\').replace(']','\]'))).match
./future/backports/email/_header_value_parser.py:1357: SyntaxWarning: invalid escape sequence '\]'
  '\\','\\\\').replace(']','\]'))).match
./future/backports/email/_header_value_parser.py:1541: SyntaxWarning: invalid escape sequence '\ '
  """ctext = <printable ascii except \ ( )>
./future/backports/email/_header_value_parser.py:1876: SyntaxWarning: invalid escape sequence '\ '
  """ dtext = <printable ascii except \ [ ]> / obs-dtext
./future/backports/email/feedparser.py:37: SyntaxWarning: invalid escape sequence '\Z'
  NLCRE_eol = re.compile('(\r\n|\r|\n)\Z')
./future/backports/email/utils.py:68: SyntaxWarning: invalid escape sequence '\A'
  '([^\ud800-\udbff]|\A)[\udc00-\udfff]([^\udc00-\udfff]|\Z)').search
./future/backports/html/parser.py:31: SyntaxWarning: invalid escape sequence '\s'
  tagfind = re.compile('([a-zA-Z][-.a-zA-Z0-9:_]*)(?:\s|/(?!>))*')
./future/backports/html/parser.py:79: SyntaxWarning: invalid escape sequence '\s'
  endtagfind = re.compile('</\s*([a-zA-Z][-.a-zA-Z0-9:_]*)\s*>')
./future/backports/http/client.py:1: SyntaxWarning: invalid escape sequence '\_'
  """HTTP/1.1 client library
./future/backports/http/cookiejar.py:212: SyntaxWarning: invalid escape sequence '\d'
  "(\d\d\d\d) (\d\d):(\d\d):(\d\d) GMT$", re.ASCII)
./future/backports/http/cookiejar.py:293: SyntaxWarning: invalid escape sequence '\d'
  """^
./future/backports/http/cookiejar.py:429: SyntaxWarning: invalid escape sequence '\s'
  non_junk, nr_junk_chars = re.subn("^[=\s;]*", "", text)
./future/backports/test/support.py:1945: SyntaxWarning: invalid escape sequence '\d'
  m = re.match("2.6.(\d{1,2})", kernel_version)
./future/backports/urllib/parse.py:957: SyntaxWarning: invalid escape sequence '\?'
  _queryprog = re.compile('^(.*)\?([^?]*)$')
```

This PR fixes all of them.